### PR TITLE
gateway,observability: set ipFamilyPolicy PreferDualStack on LoadBalancer Services

### DIFF
--- a/pkg/cluster/assets/gateway/traefik.yaml
+++ b/pkg/cluster/assets/gateway/traefik.yaml
@@ -123,6 +123,7 @@ metadata:
   # the node kiac-lb prefers, so delivery is pod-local.
 spec:
   type: LoadBalancer
+  ipFamilyPolicy: PreferDualStack
   selector:
     app: traefik
   ports:

--- a/pkg/cluster/assets/observability/grafana.yaml
+++ b/pkg/cluster/assets/observability/grafana.yaml
@@ -198,6 +198,7 @@ metadata:
   # keeps the pod on the node kiac-lb prefers, so delivery is pod-local.
 spec:
   type: LoadBalancer
+  ipFamilyPolicy: PreferDualStack
   selector:
     app: grafana
   ports:


### PR DESCRIPTION
Fixes #13
gateway installs the traefik svc with no ipFamilyPolicy set so k8s defaults it to SingleStack (v4 only) even on ip-family dual clusters. kiac-lb already hands out dual stack addrs, svc just never asked for both families.
set ipFamilyPolicy: PreferDualStack on the traefik svc (kiac-gateway) and also on grafana (kiac-observability), issue asked to check other bundled LBs and grafana had the same gap.
PreferDualStack gets both v4/v6 on dual stack clusters and falls back to single stack v4 automatically otherwise, so v4 only clusters arent affected.
also checked feat/ipv6-dual-stack branch, doesnt touch either file so no overlap with #11