### PR TITLE
Remount /proc/sys read-write before enabling ip_forward

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -225,7 +225,9 @@ func (m *Manager) Create(cfg Config) error {
 			if err := m.rt.WaitReady(n, cfg.WaitTimeout); err != nil {
 				return err
 			}
-			if _, err := m.rt.Exec(n, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+			// container CLI 1.2.0 mounts /proc/sys read-only (OCI readonlyPaths);
+			// the node VM has no user namespace, so root can lift it. No-op on <=1.1.0.
+			if _, err := m.rt.Exec(n, "sh", "-c", "mount -o remount,rw /proc/sys 2>/dev/null; sysctl -w net.ipv4.ip_forward=1"); err != nil {
 				return err
 			}
 			if cfg.family().WantsIPv6() {

--- a/pkg/cluster/persist.go
+++ b/pkg/cluster/persist.go
@@ -72,7 +72,9 @@ func (m *Manager) Resume(name string, waitTimeout time.Duration) error {
 				return err
 			}
 			// ip_forward is runtime state; the reboot reset it.
-			if _, err := m.rt.Exec(n, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+			// container CLI 1.2.0 mounts /proc/sys read-only (OCI readonlyPaths);
+			// the node VM has no user namespace, so root can lift it. No-op on <=1.1.0.
+			if _, err := m.rt.Exec(n, "sh", "-c", "mount -o remount,rw /proc/sys 2>/dev/null; sysctl -w net.ipv4.ip_forward=1"); err != nil {
 				return err
 			}
 			// A dual-stack node's kubelet --node-ip pins the OLD v4 and v6


### PR DESCRIPTION
apple/container 1.2.0 applies the OCI-default readonlyPaths (including /proc/sys) to every container, with no CLI flag to opt out, so the post-boot sysctl fails with EACCES even though nodes run with --cap-add ALL. Node VMs have no user namespace, so root inside the VM can lift the read-only bind mount with a remount; the whole VM shares one mount namespace, so a single remount also unblocks every later sysctl write (kubelet, kube-proxy, ipv6BootPrep). On container <= 1.1.0 /proc/sys is already read-write and the remount is a no-op.

Fixes #14