### PR TITLE
preflight,doctor: fail fast on apple/container 1.2.0 (sysctl permission denied on node boot)

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -41,6 +41,9 @@ var doctorCmd = &cobra.Command{
 		case majorVersion(ver) < 1:
 			failures++
 			ui.Check(false, "apple/container CLI", ver+" - upgrade to 1.0.0+ for best results")
+		case ver == "1.2.0":
+			failures++
+			ui.Check(false, "apple/container CLI", ver+" - known to break node VM boot (sysctl permission denied); downgrade to 1.1.0, see kiac#14")
 		default:
 			ui.Check(true, "apple/container CLI", ver)
 		}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -584,6 +584,12 @@ func (m *Manager) preflight() error {
 	if !m.rt.Available() {
 		return fmt.Errorf("apple/container CLI not found on PATH; install it from https://github.com/apple/container/releases")
 	}
+	// container 1.2.0 denies `sysctl -w net.ipv4.ip_forward=1` inside node
+	// VMs even with --cap-add ALL (permission denied on /proc/sys), which
+	// breaks every node boot. 1.1.0 is confirmed working; see issue #14.
+	if ver, err := m.rt.Version(); err == nil && ver == "1.2.0" {
+		return fmt.Errorf("apple/container 1.2.0 is known to break node VM boot (sysctl permission denied on net.ipv4.ip_forward); downgrade to 1.1.0 until this is fixed upstream, see https://github.com/saiyam1814/kiac/issues/14")
+	}
 	if !m.rt.SystemRunning() {
 		if err := m.rt.SystemStart(); err != nil {
 			return fmt.Errorf("container system service is not running and could not be started: %w", err)


### PR DESCRIPTION
Fixes #14

apple/container 1.2.0 denies sysctl -w net.ipv4.ip_forward=1 inside node VMs w permission denied, even tho kiac already passes 
--cap-add ALL 
reporter confirmed 1.1.0 works w the exact same kiac commands.

checked, theres no --sysctl or --privileged flag on container run/create at all (went thru the full command reference), so this isnt something kiac can patch around client side even if we knew the exact root cause. my guess is the OCI maskedPaths/readonlyPaths support that landed in 1.2.0 (apple/container#1996), if /proc/sys got added to the default readonly list that'd explain the denied write regardless of caps, but couldnt confirm on real hw.

given that, this isnt a real fix for the underlying behavior, its a fail fast. same pattern kiac already uses for the vmnet reconnect quirk in the readme.

changes:
- preflight( ) in pkg/cluster/cluster.go now rejects container 1.2.0 before any VM gets created, points at the 1.1.0 workaround and this issue instead of letting the raw sysctl error surface mid boot
- kiac doctor flags 1.2.0 the same way it already flags <1.0.0

**go build and go test ./pkg/runtime/... ./pkg/cluster/... ./cmd/...** all pass. 
havent been able to verify the actual preflight error fires on a real 1.2.0 install tho, no apple silicon hw on my end. 
would appreciate someone testing that before merge.