### PR TITLE
release: clarify container 1.2 Homebrew requirement

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ brews:
     dependencies:
       - name: kubernetes-cli
     caveats: |
-      kiac needs apple/container 1.0+:
+      kiac needs apple/container 1.0+ (skip 1.2.0; use 1.2.1 or newer):
         https://github.com/apple/container/releases
       Then: kiac doctor
 


### PR DESCRIPTION
Updates the GoReleaser-generated Homebrew caveat to exclude incompatible apple/container 1.2.0 and direct users to 1.2.1+. `goreleaser check` and a clean snapshot release both pass; the generated formula contains the corrected caveat.