### PR TITLE
feat: add cluster verification and support bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Containers are great for packaging software, and kiac depends on them. The point
 - 🌍 **IPv6 and dual-stack** — `--ip-family dual` (or `ipv6`) gives pods, Services, and nodes real IPv6, with kube-proxy programming IPv6 ClusterIP/NodePort/LoadBalancer rules on the full kernel. kiac-lb hands out both families, the edge proxy fixes v6 large uploads too, and `kiac resume` heals both. See [docs/design/ipv6-dual-stack.md](docs/design/ipv6-dual-stack.md).
 - 🚪 **Gateway API built in** — `--gateway` installs the Gateway API CRDs and Traefik with a ready-to-use GatewayClass and Gateway, so an HTTPRoute works out of the box.
 - 💥 **Node chaos you can trust** — `kiac stop node` / `kiac start node` stop and restart a real node VM: NotReady detection, eviction, rescheduling, rejoin.
+- **Diagnostics with an exit code** — `kiac verify cluster` checks the VM, Kubernetes, DNS, storage, metrics, edge proxy, LoadBalancer, Gateway, observability, and host API paths without changing the cluster. JSON output is stable for automation; `kiac support bundle` writes a bounded, redacted archive for issue reports.
 - 📄 **Declarative clusters** — `kiac create cluster --config cluster.yaml` describes the whole cluster in one file; explicit flags override it.
 - 🖥️ **A console when you want one** — `kiac ui` opens a local web console: cluster cards, live resource bars, node stop/start buttons, Grafana and Gateway links, a create form, and a per-cluster kubectl Console drawer (loopback-only, no shell). Works on every distro. Same engine as the CLI.
 - 🍎 **Native stack** — one Swift runtime from Apple, one Go binary from us. Coexists with Docker Desktop, kind, and k3d; never touches the Docker socket.
@@ -198,6 +199,9 @@ kiac get nodes --name dev
 kiac stop node worker-1 --name dev           # real node failure: NotReady, eviction, rescheduling
 kiac start node worker-1 --name dev          # node rejoins; idempotent
 kiac resume cluster --name dev               # bring a cluster back after a host reboot; idempotent
+kiac verify cluster --name dev               # read-only end-to-end health checks
+kiac verify cluster --name dev -o json       # stable schema + nonzero exit on required failures
+kiac support bundle --name dev               # redacted diagnostic archive for an issue
 container build -t myapp:dev .               # build with apple/container
 kiac load image myapp:dev --name dev         # push it into every node
 kiac completion zsh                          # bash|zsh|fish|powershell; see kiac completion -h

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,5 +35,5 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.AddCommand(createCmd, deleteCmd, getCmd, loadCmd, doctorCmd, versionCmd)
+	rootCmd.AddCommand(createCmd, deleteCmd, getCmd, loadCmd, doctorCmd, verifyCmd, supportCmd, versionCmd)
 }

--- a/cmd/support.go
+++ b/cmd/support.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/saiyam1814/kiac/pkg/cluster"
+	"github.com/saiyam1814/kiac/pkg/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	supportName    string
+	supportOutput  string
+	supportTimeout time.Duration
+)
+
+var supportCmd = &cobra.Command{
+	Use:   "support",
+	Short: "Collect troubleshooting information",
+}
+
+var supportBundleCmd = &cobra.Command{
+	Use:   "bundle",
+	Short: "Write a redacted, bounded diagnostic archive",
+	Long: `Write a redacted, bounded diagnostic archive for one cluster.
+
+Collection is read-only. Kubeconfigs, Kubernetes Secrets, raw container
+inspection, process environments, and application logs are excluded. Review
+the archive before sharing it because names, IPs, events, and system logs remain.`,
+	Example: "  kiac support bundle --name dev\n  kiac support bundle --name dev --output /tmp/dev-support.tar.gz",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ui.Banner(Version)
+		var result cluster.SupportBundleResult
+		if err := ui.Step("Collecting redacted diagnostics", func() error {
+			var err error
+			result, err = cluster.NewManager().SupportBundle(supportName, cluster.SupportBundleOptions{
+				Output:         supportOutput,
+				KiacVersion:    Version,
+				CommandTimeout: supportTimeout,
+			})
+			return err
+		}); err != nil {
+			return err
+		}
+		ui.Successf("Support bundle written to %s", result.Path)
+		ui.Infof("%d redacted file(s), archive mode 0600", result.Files)
+		if len(result.Warnings) > 0 {
+			ui.Warnf("%d diagnostic command(s) could not be collected; their failures are recorded in the archive", len(result.Warnings))
+		}
+		ui.Hintf("review contents: tar -tzf %s", result.Path)
+		return nil
+	},
+}
+
+func init() {
+	supportBundleCmd.Flags().StringVar(&supportName, "name", "dev", "cluster name")
+	supportBundleCmd.Flags().StringVarP(&supportOutput, "output", "o", "", "archive path (default: timestamped file in the current directory)")
+	supportBundleCmd.Flags().DurationVar(&supportTimeout, "timeout", 10*time.Second, "maximum duration of each diagnostic command")
+	supportCmd.AddCommand(supportBundleCmd)
+}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/saiyam1814/kiac/pkg/cluster"
+	"github.com/saiyam1814/kiac/pkg/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	verifyName    string
+	verifyOutput  string
+	verifyTimeout time.Duration
+)
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Run read-only health checks",
+}
+
+var verifyClusterCmd = &cobra.Command{
+	Use:     "cluster",
+	Short:   "Verify a kiac cluster from its VMs through the host API path",
+	Example: "  kiac verify cluster --name dev\n  kiac verify cluster --name dev -o json",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if verifyOutput != "text" && verifyOutput != "json" {
+			return fmt.Errorf("unknown output format %q (supported: text, json)", verifyOutput)
+		}
+		report, err := cluster.NewManager().Verify(verifyName, verifyTimeout)
+		if err != nil {
+			return err
+		}
+		if verifyOutput == "json" {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(report); err != nil {
+				return err
+			}
+		} else {
+			ui.Banner(Version)
+			fmt.Printf("\nCluster %s (%s)\n", report.Cluster, report.Distro)
+			for _, check := range report.Checks {
+				switch check.Status {
+				case cluster.VerificationPass:
+					ui.Check(true, check.Name, check.Detail)
+				case cluster.VerificationFail:
+					ui.Check(false, check.Name, check.Detail)
+				case cluster.VerificationWarn:
+					ui.Warnf("%s: %s", check.Name, check.Detail)
+				case cluster.VerificationSkip:
+					ui.Infof("skip %s: %s", check.Name, check.Detail)
+				}
+				if check.Hint != "" && check.Status != cluster.VerificationPass {
+					ui.Hintf("%s", check.Hint)
+				}
+			}
+			fmt.Printf("\nChecked in %s: %d failed, %d warning(s).\n",
+				report.Duration, report.FailureCount(), verificationWarnings(report))
+		}
+		if failures := report.FailureCount(); failures > 0 {
+			return fmt.Errorf("cluster %q failed %d verification check(s)", report.Cluster, failures)
+		}
+		return nil
+	},
+}
+
+func verificationWarnings(report cluster.VerificationReport) int {
+	n := 0
+	for _, check := range report.Checks {
+		if check.Status == cluster.VerificationWarn {
+			n++
+		}
+	}
+	return n
+}
+
+func init() {
+	verifyClusterCmd.Flags().StringVar(&verifyName, "name", "dev", "cluster name")
+	verifyClusterCmd.Flags().StringVarP(&verifyOutput, "output", "o", "text", "output format: text or json")
+	verifyClusterCmd.Flags().DurationVar(&verifyTimeout, "timeout", 10*time.Second, "maximum duration of each node diagnostic command")
+	verifyCmd.AddCommand(verifyClusterCmd)
+}

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -137,6 +137,28 @@ kiac start node worker-2 --name staging</code></pre>
     <tr><td><code>--wait</code></td><td><code>5m</code></td><td>how long to wait for boot, API server, and node readiness</td></tr>
   </table>
 
+  <h2 id="verify-cluster">kiac verify cluster</h2>
+  <p>Run read-only health checks across the node VMs, required node services, API readiness, Kubernetes nodes and workloads, DNS, storage, metrics, the edge proxy and its redirect rules, LoadBalancer assignments, optional Gateway and observability addons, and reachability from the Mac. Intentionally disabled addons report <code>skip</code>; required failures make the command exit nonzero.</p>
+  <pre><code>kiac verify cluster --name dev
+kiac verify cluster --name dev -o json</code></pre>
+  <table>
+    <tr><th>Flag</th><th>Default</th><th>Description</th></tr>
+    <tr><td><code>--name</code></td><td><code>dev</code></td><td>cluster name</td></tr>
+    <tr><td><code>-o, --output</code></td><td><code>text</code></td><td>output format: <code>text</code> or stable-schema <code>json</code></td></tr>
+    <tr><td><code>--timeout</code></td><td><code>10s</code></td><td>maximum duration of each node diagnostic command</td></tr>
+  </table>
+
+  <h2 id="support-bundle">kiac support bundle</h2>
+  <p>Write a mode-<code>0600</code>, bounded, redacted <code>tar.gz</code> with the verification report, host and Apple container runtime status, safe Kubernetes listings, and node system logs. Collection is read-only and excludes kubeconfigs, Kubernetes Secrets, raw container inspection, process environments, application logs, and edge-proxy credential files. Names, IPs, events, and system logs remain operational data, so review the archive before sharing it.</p>
+  <pre><code>kiac support bundle --name dev
+kiac support bundle --name dev --output /tmp/dev-support.tar.gz</code></pre>
+  <table>
+    <tr><th>Flag</th><th>Default</th><th>Description</th></tr>
+    <tr><td><code>--name</code></td><td><code>dev</code></td><td>cluster name</td></tr>
+    <tr><td><code>-o, --output</code></td><td>timestamped file</td><td>archive path; an existing file is never overwritten</td></tr>
+    <tr><td><code>--timeout</code></td><td><code>10s</code></td><td>maximum duration of each diagnostic command</td></tr>
+  </table>
+
   <h2 id="load-image">kiac load image</h2>
   <p>Copy images from the apple/container local image store into the containerd instance of every node VM, so pods can run them without pushing to a registry. Build first with <code>container build -t myapp .</code>, and set <code>imagePullPolicy: IfNotPresent</code> (or <code>Never</code>) in your pod spec.</p>
   <pre><code>kiac load image myapp:dev --name dev

--- a/docs/docs/contributing.html
+++ b/docs/docs/contributing.html
@@ -73,7 +73,7 @@ make ci             <span class="c"># exact formatting, generation, race, vet, a
   <table>
     <tr><th>Path</th><th>What lives there</th></tr>
     <tr><td><code>cmd/</code></td><td>cobra commands; deliberately thin shims over pkg/cluster</td></tr>
-    <tr><td><code>pkg/cluster/</code></td><td>cluster lifecycle: create, delete, addons, chaos, kubeconfig, status</td></tr>
+    <tr><td><code>pkg/cluster/</code></td><td>cluster lifecycle: create, delete, addons, chaos, diagnostics, kubeconfig, status</td></tr>
     <tr><td><code>pkg/cluster/assets/</code></td><td>embedded manifests (metrics-server, observability, gateway, k3s kindnet), versions pinned</td></tr>
     <tr><td><code>pkg/runtime/</code></td><td>wrapper around the apple/container CLI</td></tr>
     <tr><td><code>pkg/webui/</code></td><td>the local dashboard: Go handlers + one embedded HTML file</td></tr>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -94,7 +94,9 @@ git clone https://github.com/saiyam1814/kiac &amp;&amp; cd kiac &amp;&amp; make 
   <pre><code>kiac create cluster --name dev --workers 2</code></pre>
   <p>That boots three lightweight VMs (one control plane, two workers), initializes Kubernetes with kubeadm, installs the kindnet CNI plus the default addons, and merges the kubeconfig into <code>~/.kube/config</code> as context <code>kiac-dev</code>.</p>
   <pre><code>kubectl get nodes
-kubectl top nodes    <span class="c"># native metrics, give it ~60s to scrape</span></code></pre>
+kubectl top nodes    <span class="c"># native metrics, give it ~60s to scrape</span>
+kiac verify cluster --name dev</code></pre>
+  <p><code>kiac verify cluster</code> is read-only and checks the complete path from each node VM and its services through Kubernetes readiness, DNS, storage, metrics, networking helpers, optional addons, and the Mac-to-API connection. Use <code>-o json</code> for a stable automation schema and a nonzero exit when a required check fails.</p>
   <p>Supported Kubernetes versions are 1.32 through 1.36 (pinned image digests); 1.36 is the default. Pick one with <code>--k8s-version 1.34</code>, on either distro. In a hurry? <code>kiac create cluster --distro k3s --workers 1</code> is Ready in well under a minute.</p>
 
   <div class="note"><b>Where next?</b>

--- a/docs/docs/troubleshooting.html
+++ b/docs/docs/troubleshooting.html
@@ -65,6 +65,11 @@ kiac doctor --fix  <span class="c"># also starts the container system service if
 kiac delete cluster --name dev
 kiac create cluster --name dev --workers 2</code></pre>
 
+  <h2 id="verify-cluster">Second move: verify the cluster</h2>
+  <pre><code>kiac verify cluster --name dev
+kiac verify cluster --name dev -o json</code></pre>
+  <p>The check is read-only and follows the complete user path: VM and node services, Kubernetes API and Ready state, workloads, DNS, storage and metrics, edge-proxy process plus iptables hooks, LoadBalancer assignment, optional Gateway and observability stacks, and the Mac-to-API connection. A failed required check exits nonzero and includes the next command to inspect; an addon you intentionally disabled is shown as skipped.</p>
+
   <h2 id="reboot">After a reboot: clusters show 0/N</h2>
   <pre><code>kiac get clusters
 <span class="o">NAME  STATUS
@@ -128,7 +133,7 @@ dev   0/3 stopped</span></code></pre>
 container exec kiac-dev-control-plane kubectl get nodes
 
 <span class="c"># restore kubectl from your Mac: reset vmnet, then heal the cluster</span>
-container system stop && container system start
+container system stop &amp;&amp; container system start
 kiac resume cluster --name dev</code></pre>
   <p>A full <code>container system</code> restart tears down and rebuilds vmnet (clearing the stale ARP state), and <code>kiac resume</code> re-points every node, kubeconfig, and certificate SAN at the fresh IPs. This is being tracked upstream at apple/container; see <a href="https://github.com/saiyam1814/kiac/issues/6">issue #6</a>.</p>
 
@@ -158,7 +163,10 @@ container exec kiac-dev-control-plane tail -50 /var/log/kiac-edge-proxy.log</cod
   <p>kiac only touches entries named <code>kiac-&lt;cluster&gt;</code>, and the first time it modifies your kubeconfig it saves the original to <code>~/.kube/config.kiac.bak</code>. <code>kiac delete cluster</code> removes exactly the cluster's entries and clears <code>current-context</code> if it pointed there.</p>
 
   <h2 id="still-stuck">Still stuck?</h2>
-  <p>Open an issue with the failing command's output: <a href="https://github.com/saiyam1814/kiac/issues">github.com/saiyam1814/kiac/issues</a>.</p>
+  <p>Generate a support archive, review its contents, and attach it with the failing command's output:</p>
+  <pre><code>kiac support bundle --name dev
+tar -tzf kiac-support-dev-*.tar.gz</code></pre>
+  <p>The bundle is mode <code>0600</code>, bounded, and redacted. It excludes kubeconfigs, Kubernetes Secrets, raw container inspection, process environments, application logs, and edge-proxy credential files. It still contains operational names, IPs, events, and system logs, so review it before opening an issue at <a href="https://github.com/saiyam1814/kiac/issues">github.com/saiyam1814/kiac/issues</a>.</p>
 
   <div class="pn">
     <a href="dashboard.html"><span>Previous</span>Dashboard (kiac ui)</a>

--- a/pkg/cluster/support.go
+++ b/pkg/cluster/support.go
@@ -1,0 +1,416 @@
+package cluster
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/saiyam1814/kiac/pkg/runtime"
+)
+
+const maxSupportFileBytes = 512 << 10
+
+// SupportBundleOptions controls collection without changing cluster state.
+type SupportBundleOptions struct {
+	Output         string
+	KiacVersion    string
+	CommandTimeout time.Duration
+}
+
+// SupportBundleResult describes the archive written for the user.
+type SupportBundleResult struct {
+	Path     string
+	Files    int
+	Warnings []string
+}
+
+type supportFile struct {
+	name string
+	data []byte
+}
+
+type supportCollector struct {
+	files    []supportFile
+	warnings []string
+	home     string
+}
+
+// SupportBundle collects bounded, read-only diagnostics. It deliberately does
+// not read kubeconfigs, Kubernetes Secrets, container inspect output, process
+// environments, or workload logs. All collected text still passes through the
+// credential redactor before it reaches disk.
+func (m *Manager) SupportBundle(name string, opts SupportBundleOptions) (SupportBundleResult, error) {
+	if !ValidName(name) {
+		return SupportBundleResult{}, fmt.Errorf("invalid cluster name %q: use lowercase letters, digits, and dashes", name)
+	}
+	if opts.CommandTimeout <= 0 {
+		opts.CommandTimeout = 10 * time.Second
+	}
+	now := time.Now().UTC()
+	output, err := supportOutputPath(name, now, opts.Output)
+	if err != nil {
+		return SupportBundleResult{}, err
+	}
+	infos, err := m.rt.List(prefix(name))
+	if err != nil {
+		return SupportBundleResult{}, err
+	}
+	if len(infos) == 0 {
+		return SupportBundleResult{}, fmt.Errorf("no cluster named %q found", name)
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+	distro := distroFromNodes(infos)
+	cp := ControlPlane(name)
+
+	home, _ := os.UserHomeDir()
+	collector := &supportCollector{home: home}
+	collector.addText("README.txt", supportBundleReadme)
+
+	report, verifyErr := m.Verify(name, opts.CommandTimeout)
+	if verifyErr != nil {
+		collector.warnings = append(collector.warnings, "verification: "+compactError(verifyErr))
+	}
+	collector.addJSON("cluster/verify.json", report)
+
+	version, versionErr := m.rt.Version()
+	if versionErr != nil {
+		collector.warnings = append(collector.warnings, "runtime version: "+compactError(versionErr))
+	}
+	statuses := BuildStatuses(infos)
+	metadata := struct {
+		SchemaVersion    int             `json:"schemaVersion"`
+		GeneratedAt      string          `json:"generatedAt"`
+		KiacVersion      string          `json:"kiacVersion"`
+		ContainerVersion string          `json:"containerVersion,omitempty"`
+		Cluster          string          `json:"cluster"`
+		Distro           string          `json:"distro"`
+		Status           []ClusterStatus `json:"status"`
+	}{
+		SchemaVersion:    1,
+		GeneratedAt:      now.Format(time.RFC3339),
+		KiacVersion:      opts.KiacVersion,
+		ContainerVersion: version,
+		Cluster:          name,
+		Distro:           distro,
+		Status:           statuses,
+	}
+	collector.addJSON("metadata.json", metadata)
+
+	collector.collectHost(m.rt, opts.CommandTimeout)
+	collector.collectKubernetes(m, cp, distro, report, opts.CommandTimeout)
+	collector.collectNodes(m.rt, infos, distro, opts.CommandTimeout)
+
+	if err := writeSupportArchive(output, "kiac-support-"+name, now, collector.files); err != nil {
+		return SupportBundleResult{}, err
+	}
+	return SupportBundleResult{Path: output, Files: len(collector.files), Warnings: collector.warnings}, nil
+}
+
+func (c *supportCollector) collectHost(rt *runtime.Client, timeout time.Duration) {
+	out, err := hostDiagnosticCommand(timeout, "sw_vers")
+	c.addCommand("host/macos.txt", "sw_vers", out, err, true)
+	out, err = hostDiagnosticCommand(timeout, "uname", "-mrs")
+	c.addCommand("host/kernel.txt", "uname -mrs", out, err, true)
+	out, err = rt.SystemStatus(timeout)
+	c.addCommand("runtime/system-status.txt", "container system status", out, err, false)
+}
+
+func (c *supportCollector) collectKubernetes(m *Manager, cp, distro string, report VerificationReport, timeout time.Duration) {
+	if !verificationReachedAPI(report) {
+		c.addText("kubernetes/NOT-COLLECTED.txt", "The control-plane VM or Kubernetes API was unavailable. See cluster/verify.json.\n")
+		return
+	}
+	commands := []struct {
+		file string
+		args []string
+	}{
+		{"version.txt", []string{"version", "-o", "yaml"}},
+		{"nodes.txt", []string{"get", "nodes", "-o", "wide"}},
+		{"pods.txt", []string{"get", "pods", "-A", "-o", "wide"}},
+		{"workloads.txt", []string{"get", "deployments,statefulsets,daemonsets", "-A", "-o", "wide"}},
+		{"services.txt", []string{"get", "services,endpointslices", "-A", "-o", "wide"}},
+		{"storage.txt", []string{"get", "storageclass,persistentvolumeclaim,persistentvolume", "-A", "-o", "wide"}},
+		{"api-services.txt", []string{"get", "apiservices", "-o", "wide"}},
+		{"events.txt", []string{"get", "events", "-A", "--sort-by=.metadata.creationTimestamp"}},
+	}
+	if verificationStatus(report, "metrics.api") != VerificationSkip {
+		commands = append(commands, struct {
+			file string
+			args []string
+		}{"metrics.txt", []string{"top", "nodes"}})
+	}
+	if verificationStatus(report, "gateway.api") != VerificationSkip {
+		commands = append(commands, struct {
+			file string
+			args []string
+		}{"gateway.txt", []string{"get", "gatewayclasses,gateways,httproutes", "-A", "-o", "wide"}})
+	}
+	for _, command := range commands {
+		out, err := m.diagnosticKubectl(cp, distro, timeout, command.args...)
+		full := "container exec " + cp + " kubectl " + strings.Join(command.args, " ")
+		c.addCommand("kubernetes/"+command.file, full, out, err, false)
+	}
+}
+
+func (c *supportCollector) collectNodes(rt *runtime.Client, infos []runtime.Info, distro string, timeout time.Duration) {
+	for _, info := range infos {
+		base := "nodes/" + info.Name + "/"
+		if !strings.EqualFold(info.Status, "running") {
+			c.addText(base+"NOT-COLLECTED.txt", "Node VM is "+orUnknown(info.Status)+".\n")
+			continue
+		}
+		out, err := rt.Logs(info.Name, timeout)
+		c.addCommand(base+"console.log", "container logs "+info.Name, out, err, false)
+
+		commands := []struct {
+			file string
+			args []string
+		}{
+			{"resources.txt", []string{"sh", "-c", "df -h; printf '\\n'; free -h 2>/dev/null || true"}},
+			{"network.txt", []string{"sh", "-c", "ip -brief address; printf '\\nIPv4 routes:\\n'; ip route; printf '\\nIPv6 routes:\\n'; ip -6 route 2>/dev/null || true"}},
+			{"containers.txt", []string{"sh", "-c", "crictl ps -a 2>/dev/null || ctr -n k8s.io containers list 2>/dev/null || true"}},
+			{"edge-proxy.log", []string{"sh", "-c", "tail -500 " + edgeProxyLogPath + " 2>/dev/null || true"}},
+		}
+		if distro == "k3s" {
+			if strings.HasSuffix(info.Name, "-control-plane") {
+				commands = append(commands, struct {
+					file string
+					args []string
+				}{"load-balancer.log", []string{"sh", "-c", "tail -500 " + kiacLBK3sLogPath + " 2>/dev/null || true"}})
+			}
+		} else {
+			commands = append(commands,
+				struct {
+					file string
+					args []string
+				}{"kubelet.log", []string{"journalctl", "--no-pager", "-n", "500", "-u", "kubelet"}},
+				struct {
+					file string
+					args []string
+				}{"containerd.log", []string{"journalctl", "--no-pager", "-n", "500", "-u", "containerd"}},
+			)
+			if strings.HasSuffix(info.Name, "-control-plane") {
+				commands = append(commands, struct {
+					file string
+					args []string
+				}{"load-balancer.log", []string{"journalctl", "--no-pager", "-n", "500", "-u", "kiac-lb"}})
+			}
+		}
+		for _, command := range commands {
+			out, err := rt.ExecTimeout(info.Name, timeout, command.args...)
+			full := "container exec " + info.Name + " " + strings.Join(command.args, " ")
+			c.addCommand(base+command.file, full, out, err, false)
+		}
+	}
+}
+
+func (c *supportCollector) addJSON(name string, value any) {
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		c.warnings = append(c.warnings, name+": "+err.Error())
+		c.addText(name, "JSON encoding failed: "+err.Error()+"\n")
+		return
+	}
+	c.addText(name, string(raw)+"\n")
+}
+
+func (c *supportCollector) addCommand(name, command, output string, err error, optional bool) {
+	status := "success"
+	if err != nil {
+		status = diagnosticError(err)
+		if !optional {
+			c.warnings = append(c.warnings, name+": "+compactError(err))
+		}
+	}
+	body := "Command: " + command + "\nStatus: " + status + "\n\n" + output
+	if !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	c.addText(name, body)
+}
+
+func (c *supportCollector) addText(name, text string) {
+	clean := path.Clean(strings.TrimPrefix(name, "/"))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		c.warnings = append(c.warnings, "ignored unsafe archive path: "+name)
+		return
+	}
+	text = redactSupportText(text, c.home)
+	if len(text) > maxSupportFileBytes {
+		text = truncateSupportText(text)
+	}
+	c.files = append(c.files, supportFile{name: clean, data: []byte(text)})
+}
+
+func hostDiagnosticCommand(timeout time.Duration, name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return string(out), err
+}
+
+func diagnosticError(err error) string {
+	var commandErr *runtime.CommandError
+	if errors.As(err, &commandErr) {
+		return "failed: " + compact(commandErr.Err.Error())
+	}
+	return "failed: " + compact(err.Error())
+}
+
+func verificationReachedAPI(report VerificationReport) bool {
+	return verificationStatus(report, "kubernetes.api") == VerificationPass
+}
+
+func verificationStatus(report VerificationReport, id string) VerificationStatus {
+	for _, check := range report.Checks {
+		if check.ID == id {
+			return check.Status
+		}
+	}
+	return VerificationSkip
+}
+
+func supportOutputPath(name string, now time.Time, requested string) (string, error) {
+	filename := fmt.Sprintf("kiac-support-%s-%s.tar.gz", name, now.Format("20060102T150405Z"))
+	if requested == "" {
+		requested = filename
+	} else if info, err := os.Stat(requested); err == nil && info.IsDir() {
+		requested = filepath.Join(requested, filename)
+	} else if !strings.HasSuffix(requested, ".tar.gz") && !strings.HasSuffix(requested, ".tgz") {
+		requested += ".tar.gz"
+	}
+	abs, err := filepath.Abs(requested)
+	if err != nil {
+		return "", fmt.Errorf("resolving support bundle path: %w", err)
+	}
+	return abs, nil
+}
+
+func truncateSupportText(text string) string {
+	half := (maxSupportFileBytes - 100) / 2
+	headEnd := half
+	for headEnd > 0 && !utf8.RuneStart(text[headEnd]) {
+		headEnd--
+	}
+	tailStart := len(text) - half
+	for tailStart < len(text) && !utf8.RuneStart(text[tailStart]) {
+		tailStart++
+	}
+	return text[:headEnd] + "\n\n[... output truncated by kiac ...]\n\n" + text[tailStart:]
+}
+
+func writeSupportArchive(output, root string, now time.Time, files []supportFile) (err error) {
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		return fmt.Errorf("creating support bundle directory: %w", err)
+	}
+	f, err := os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating support bundle %s: %w", output, err)
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			_ = f.Close()
+			_ = os.Remove(output)
+		}
+	}()
+
+	gz, err := gzip.NewWriterLevel(f, gzip.BestSpeed)
+	if err != nil {
+		return err
+	}
+	tw := tar.NewWriter(gz)
+	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+	for _, file := range files {
+		name := path.Join(root, file.name)
+		header := &tar.Header{
+			Name:    name,
+			Mode:    0o600,
+			Size:    int64(len(file.data)),
+			ModTime: now,
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			_ = tw.Close()
+			_ = gz.Close()
+			return fmt.Errorf("writing support bundle header: %w", err)
+		}
+		if _, err := tw.Write(file.data); err != nil {
+			_ = tw.Close()
+			_ = gz.Close()
+			return fmt.Errorf("writing support bundle data: %w", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		_ = gz.Close()
+		return fmt.Errorf("finishing support bundle: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("compressing support bundle: %w", err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		return fmt.Errorf("securing support bundle: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing support bundle: %w", err)
+	}
+	complete = true
+	return nil
+}
+
+var supportRedactions = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	{regexp.MustCompile(`(?is)-----BEGIN [^-\n]*PRIVATE KEY-----.*?-----END [^-\n]*PRIVATE KEY-----`), "[REDACTED PRIVATE KEY]"},
+	{regexp.MustCompile(`(?im)^(\s*"?(?:token|password|client-key-data|client-certificate-data|certificate-authority-data|k3s_token|tunnel_token)"?\s*[:=]\s*).+$`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(authorization\s*[:=]\s*bearer\s+)\S+`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(--(?:token|password)(?:=|\s+))\S+`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`K10[a-zA-Z0-9._:-]+::server:[a-zA-Z0-9]+`), "[REDACTED K3S TOKEN]"},
+	{regexp.MustCompile(`(?i)((?:tunnel[._-]?token|k3s_token)\s*[:=]\s*)[a-f0-9]{32,}`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(https?://[^\s:/]+:)[^@\s]+@`), `${1}[REDACTED]@`},
+}
+
+func redactSupportText(text, home string) string {
+	if !utf8.ValidString(text) {
+		text = strings.ToValidUTF8(text, "?")
+	}
+	if home != "" && home != "/" {
+		text = strings.ReplaceAll(text, home, "$HOME")
+	}
+	for _, redaction := range supportRedactions {
+		text = redaction.re.ReplaceAllString(text, redaction.repl)
+	}
+	return text
+}
+
+const supportBundleReadme = `kiac support bundle
+
+This archive contains read-only host, Apple container runtime, Kubernetes,
+and kiac node diagnostics. It intentionally excludes:
+
+- kubeconfig files and client certificates
+- Kubernetes Secret objects
+- raw container inspect output and process environments
+- application workload logs
+- edge-proxy token and credential files
+
+Collected text is bounded and passed through credential-pattern redaction.
+Names, image references, IP addresses, Kubernetes events, and system logs are
+still operational data. Review the archive before sharing it publicly.
+`

--- a/pkg/cluster/support_test.go
+++ b/pkg/cluster/support_test.go
@@ -1,0 +1,130 @@
+package cluster
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func TestRedactSupportText(t *testing.T) {
+	raw := `/Users/test/kiac
+token: secret-token
+"password": "hunter2"
+client-key-data: c2VjcmV0
+Authorization: Bearer bearer-secret
+command --token=flag-secret
+K10abcdef::server:k3s-secret
+tunnel_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+https://alice:url-secret@example.test/path
+-----BEGIN PRIVATE KEY-----
+private-secret
+-----END PRIVATE KEY-----
+ordinary diagnostic text
+`
+	got := redactSupportText(raw, "/Users/test")
+	for _, secret := range []string{"secret-token", "hunter2", "c2VjcmV0", "bearer-secret", "flag-secret", "k3s-secret", strings.Repeat("a", 64), "url-secret", "private-secret", "/Users/test"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("redacted output still contains %q:\n%s", secret, got)
+		}
+	}
+	for _, want := range []string{"$HOME/kiac", "[REDACTED]", "ordinary diagnostic text"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("redacted output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWriteSupportArchive(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "bundle.tar.gz")
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	files := []supportFile{{name: "z.txt", data: []byte("last\n")}, {name: "a/info.txt", data: []byte("first\n")}}
+	if err := writeSupportArchive(out, "kiac-support-dev", now, files); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("archive mode = %o, want 600", got)
+	}
+
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	var names []string
+	contents := map[string]string{}
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, header.Name)
+		contents[header.Name] = string(raw)
+		if header.Mode != 0o600 {
+			t.Errorf("entry %s mode = %o, want 600", header.Name, header.Mode)
+		}
+	}
+	wantNames := []string{"kiac-support-dev/a/info.txt", "kiac-support-dev/z.txt"}
+	if strings.Join(names, ",") != strings.Join(wantNames, ",") {
+		t.Errorf("archive names = %v, want %v", names, wantNames)
+	}
+	if contents[wantNames[0]] != "first\n" || contents[wantNames[1]] != "last\n" {
+		t.Errorf("archive contents = %#v", contents)
+	}
+	if err := writeSupportArchive(out, "kiac-support-dev", now, files); err == nil {
+		t.Fatal("archive writer overwrote an existing bundle")
+	}
+}
+
+func TestSupportCollectorBoundsAndRejectsUnsafePath(t *testing.T) {
+	c := &supportCollector{}
+	c.addText("../secret.txt", "must not be added")
+	c.addText("logs/large.txt", strings.Repeat("\u00e9", maxSupportFileBytes))
+	if len(c.files) != 1 || c.files[0].name != "logs/large.txt" {
+		t.Fatalf("collector files = %+v", c.files)
+	}
+	if len(c.files[0].data) > maxSupportFileBytes {
+		t.Errorf("bounded file has %d bytes, limit %d", len(c.files[0].data), maxSupportFileBytes)
+	}
+	if !utf8.Valid(c.files[0].data) {
+		t.Fatal("truncation split a UTF-8 rune")
+	}
+	if len(c.warnings) == 0 {
+		t.Fatal("unsafe path did not produce a warning")
+	}
+}
+
+func TestSupportOutputPath(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 8, 8, 12, 34, 56, 0, time.UTC)
+	got, err := supportOutputPath("dev", now, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "kiac-support-dev-20260808T123456Z.tar.gz")
+	if got != want {
+		t.Errorf("output path = %q, want %q", got, want)
+	}
+}

--- a/pkg/cluster/verify.go
+++ b/pkg/cluster/verify.go
@@ -1,0 +1,651 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/saiyam1814/kiac/pkg/runtime"
+)
+
+// VerificationStatus is the machine-readable outcome of one cluster check.
+type VerificationStatus string
+
+const (
+	VerificationPass VerificationStatus = "pass"
+	VerificationWarn VerificationStatus = "warn"
+	VerificationFail VerificationStatus = "fail"
+	VerificationSkip VerificationStatus = "skip"
+)
+
+// VerificationCheck is one stable, independently actionable health signal.
+type VerificationCheck struct {
+	ID     string             `json:"id"`
+	Name   string             `json:"name"`
+	Status VerificationStatus `json:"status"`
+	Detail string             `json:"detail,omitempty"`
+	Hint   string             `json:"hint,omitempty"`
+}
+
+// VerificationReport is emitted by `kiac verify cluster -o json` and embedded
+// in support bundles. SchemaVersion changes only for incompatible JSON changes.
+type VerificationReport struct {
+	SchemaVersion int                 `json:"schemaVersion"`
+	Cluster       string              `json:"cluster"`
+	Distro        string              `json:"distro,omitempty"`
+	Healthy       bool                `json:"healthy"`
+	CheckedAt     string              `json:"checkedAt"`
+	Duration      string              `json:"duration"`
+	Checks        []VerificationCheck `json:"checks"`
+}
+
+// FailureCount returns the number of required checks that failed.
+func (r VerificationReport) FailureCount() int {
+	n := 0
+	for _, check := range r.Checks {
+		if check.Status == VerificationFail {
+			n++
+		}
+	}
+	return n
+}
+
+// Verify inspects a cluster without changing it. timeout bounds each guest
+// command independently so one wedged node cannot hang the whole diagnostic.
+func (m *Manager) Verify(name string, timeout time.Duration) (VerificationReport, error) {
+	started := time.Now()
+	report := VerificationReport{
+		SchemaVersion: 1,
+		Cluster:       name,
+		CheckedAt:     started.UTC().Format(time.RFC3339),
+		Checks:        []VerificationCheck{},
+	}
+	finish := func() {
+		report.Duration = time.Since(started).Round(time.Millisecond).String()
+		report.Healthy = report.FailureCount() == 0
+	}
+	if !ValidName(name) {
+		finish()
+		return report, fmt.Errorf("invalid cluster name %q: use lowercase letters, digits, and dashes", name)
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	infos, err := m.rt.List(prefix(name))
+	if err != nil {
+		finish()
+		return report, err
+	}
+	if len(infos) == 0 {
+		finish()
+		return report, fmt.Errorf("no cluster named %q found", name)
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+	report.Distro = distroFromNodes(infos)
+
+	cpName := ControlPlane(name)
+	var cpInfo *runtime.Info
+	running := 0
+	for i := range infos {
+		if strings.EqualFold(infos[i].Status, "running") {
+			running++
+		}
+		if infos[i].Name == cpName {
+			cpInfo = &infos[i]
+		}
+	}
+	if cpInfo == nil {
+		report.add(VerificationFail, "runtime.layout", "cluster layout",
+			fmt.Sprintf("control plane %s is missing", cpName),
+			"restore the missing VM or recreate the cluster")
+	} else {
+		report.add(VerificationPass, "runtime.layout", "cluster layout",
+			fmt.Sprintf("control plane and %d worker(s) found", len(infos)-1), "")
+	}
+	vmStatus := VerificationPass
+	vmHint := ""
+	if running != len(infos) {
+		vmStatus = VerificationFail
+		vmHint = fmt.Sprintf("run: kiac resume cluster --name %s", name)
+	}
+	report.add(vmStatus, "runtime.nodes", "node VMs",
+		fmt.Sprintf("%d/%d running", running, len(infos)), vmHint)
+
+	for _, info := range infos {
+		id := "runtime.node." + strings.TrimPrefix(info.Name, prefix(name))
+		label := "node services: " + info.Name
+		if !strings.EqualFold(info.Status, "running") {
+			report.add(VerificationSkip, id, label, "VM is "+orUnknown(info.Status), "")
+			continue
+		}
+		var command []string
+		if report.Distro == "k3s" {
+			command = []string{"sh", "-ec", `test -r /proc/1/status && (test -x /bin/kubectl || test -x /usr/local/bin/kubectl)`}
+		} else {
+			command = []string{"systemctl", "is-active", "--quiet", "containerd", "kubelet"}
+		}
+		if _, err := m.rt.ExecTimeout(info.Name, timeout, command...); err != nil {
+			report.add(VerificationFail, id, label, "guest responds, but required node services are not healthy",
+				fmt.Sprintf("inspect: container exec %s %s", info.Name, nodeLogHint(report.Distro)))
+		} else {
+			report.add(VerificationPass, id, label, "guest and required node services are healthy", "")
+		}
+	}
+
+	if cpInfo == nil || !strings.EqualFold(cpInfo.Status, "running") {
+		report.skipKubernetesChecks("control-plane VM is not running")
+		report.add(VerificationSkip, "host.api", "API reachability from Mac", "control-plane VM is not running", "")
+		finish()
+		return report, nil
+	}
+
+	apiReady := false
+	if out, err := m.diagnosticKubectl(cpName, report.Distro, timeout, "get", "--raw=/readyz"); err != nil {
+		report.add(VerificationFail, "kubernetes.api", "Kubernetes API", compactError(err),
+			fmt.Sprintf("inspect from the VM: container exec %s kubectl get --raw=/readyz", cpName))
+	} else if !strings.Contains(strings.ToLower(out), "ok") {
+		report.add(VerificationFail, "kubernetes.api", "Kubernetes API", "readyz did not return ok: "+compact(out), "")
+	} else {
+		apiReady = true
+		report.add(VerificationPass, "kubernetes.api", "Kubernetes API", "readyz returned ok", "")
+	}
+
+	if !apiReady {
+		report.skipKubernetesDataChecks("API server is not ready")
+	} else {
+		m.verifyKubernetesData(&report, infos, cpName, timeout)
+	}
+
+	m.verifyNodeAddons(&report, infos, cpName, timeout)
+
+	ip := cpInfo.IP
+	// kubeadm's admin.conf retains the endpoint family chosen at create
+	// time. This matters for IPv6-only clusters: the VM still has a vmnet
+	// IPv4 address for egress, but the API server and host kubeconfig use
+	// its IPv6 address. k3s writes loopback into its in-VM kubeconfig, so
+	// that distro continues to use the runtime-reported node address.
+	if report.Distro == "kubeadm" {
+		if endpoint, err := m.diagnosticKubectl(cpName, report.Distro, timeout,
+			"config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}"); err == nil {
+			if host := endpointHostname(endpoint); host != "" {
+				ip = host
+			}
+		}
+	}
+	if ip == "" {
+		ip, _ = m.rt.IP(cpName)
+	}
+	if ip == "" {
+		report.add(VerificationFail, "host.api", "API reachability from Mac", "control-plane API address is unavailable", "")
+	} else {
+		endpoint := net.JoinHostPort(ip, "6443")
+		hostTimeout := timeout
+		if hostTimeout > 5*time.Second {
+			hostTimeout = 5 * time.Second
+		}
+		if hostReachAPI(ip, hostTimeout) {
+			report.add(VerificationPass, "host.api", "API reachability from Mac", endpoint+" accepts TCP connections", "")
+		} else {
+			hint := fmt.Sprintf("reset vmnet, then run: kiac resume cluster --name %s", name)
+			if parsed := net.ParseIP(ip); parsed != nil && parsed.To4() == nil {
+				hint = "inspect: container network inspect default"
+			}
+			report.add(VerificationFail, "host.api", "API reachability from Mac", endpoint+" is unreachable", hint)
+		}
+	}
+
+	finish()
+	return report, nil
+}
+
+func endpointHostname(endpoint string) string {
+	parsed, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil {
+		return ""
+	}
+	return parsed.Hostname()
+}
+
+func (r *VerificationReport) add(status VerificationStatus, id, name, detail, hint string) {
+	r.Checks = append(r.Checks, VerificationCheck{ID: id, Name: name, Status: status, Detail: detail, Hint: hint})
+}
+
+func (r *VerificationReport) skipKubernetesChecks(reason string) {
+	r.add(VerificationSkip, "kubernetes.api", "Kubernetes API", reason, "")
+	r.skipKubernetesDataChecks(reason)
+	r.add(VerificationSkip, "network.edge-proxy", "edge proxy", reason, "")
+	r.add(VerificationSkip, "network.load-balancer", "LoadBalancer controller", reason, "")
+}
+
+func (r *VerificationReport) skipKubernetesDataChecks(reason string) {
+	for _, check := range []struct{ id, name string }{
+		{"kubernetes.nodes", "Kubernetes nodes"},
+		{"kubernetes.pods", "Kubernetes workloads"},
+		{"kubernetes.dns", "cluster DNS"},
+		{"storage.default-class", "default storage"},
+		{"metrics.api", "metrics API"},
+		{"gateway.api", "Gateway API"},
+		{"observability.stack", "observability"},
+	} {
+		r.add(VerificationSkip, check.id, check.name, reason, "")
+	}
+}
+
+func (m *Manager) verifyKubernetesData(report *VerificationReport, infos []runtime.Info, cp string, timeout time.Duration) {
+	out, err := m.diagnosticKubectl(cp, report.Distro, timeout, "get", "nodes", "-o", "json")
+	if err != nil {
+		report.add(VerificationFail, "kubernetes.nodes", "Kubernetes nodes", compactError(err), "kubectl get nodes")
+	} else {
+		var list kubeNodeList
+		if err := json.Unmarshal([]byte(out), &list); err != nil {
+			report.add(VerificationFail, "kubernetes.nodes", "Kubernetes nodes", "cannot parse kubectl output: "+err.Error(), "")
+		} else {
+			registered := map[string]bool{}
+			var unready []string
+			for _, node := range list.Items {
+				registered[node.Metadata.Name] = true
+				if !conditionTrue(node.Status.Conditions, "Ready") {
+					unready = append(unready, node.Metadata.Name)
+				}
+			}
+			var missing []string
+			for _, info := range infos {
+				if !registered[info.Name] {
+					missing = append(missing, info.Name)
+				}
+			}
+			if len(missing)+len(unready) > 0 {
+				detail := joinProblems(problem("missing", missing), problem("not Ready", unready))
+				report.add(VerificationFail, "kubernetes.nodes", "Kubernetes nodes", detail, "kubectl get nodes -o wide")
+			} else {
+				report.add(VerificationPass, "kubernetes.nodes", "Kubernetes nodes",
+					fmt.Sprintf("%d/%d registered nodes are Ready", len(list.Items), len(list.Items)), "")
+			}
+		}
+	}
+
+	out, err = m.diagnosticKubectl(cp, report.Distro, timeout, "get", "pods", "-A", "-o", "json")
+	if err != nil {
+		report.add(VerificationFail, "kubernetes.pods", "Kubernetes workloads", compactError(err), "kubectl get pods -A")
+	} else {
+		var list kubePodList
+		if err := json.Unmarshal([]byte(out), &list); err != nil {
+			report.add(VerificationFail, "kubernetes.pods", "Kubernetes workloads", "cannot parse kubectl output: "+err.Error(), "")
+		} else {
+			var unhealthy []string
+			for _, pod := range list.Items {
+				if pod.Metadata.DeletionTimestamp != "" || pod.Status.Phase == "Succeeded" {
+					continue
+				}
+				ready := pod.Status.Phase == "Running" && len(pod.Status.ContainerStatuses) > 0
+				for _, container := range pod.Status.ContainerStatuses {
+					ready = ready && container.Ready
+				}
+				if !ready {
+					unhealthy = append(unhealthy, pod.Metadata.Namespace+"/"+pod.Metadata.Name+" ("+orUnknown(pod.Status.Phase)+")")
+				}
+			}
+			if len(unhealthy) > 0 {
+				report.add(VerificationFail, "kubernetes.pods", "Kubernetes workloads",
+					fmt.Sprintf("%d unhealthy: %s", len(unhealthy), limitedList(unhealthy, 6)), "kubectl get pods -A -o wide")
+			} else {
+				report.add(VerificationPass, "kubernetes.pods", "Kubernetes workloads",
+					fmt.Sprintf("%d pod(s) Running/Ready or Succeeded", len(list.Items)), "")
+			}
+		}
+	}
+
+	out, err = m.diagnosticKubectl(cp, report.Distro, timeout, "get", "endpointslice", "-n", "kube-system", "-l", "k8s-app=kube-dns", "-o", "json")
+	if err != nil {
+		report.add(VerificationFail, "kubernetes.dns", "cluster DNS", compactError(err), "kubectl -n kube-system get pods,svc,endpointslice -l k8s-app=kube-dns")
+	} else {
+		var list kubeEndpointSliceList
+		if err := json.Unmarshal([]byte(out), &list); err != nil {
+			report.add(VerificationFail, "kubernetes.dns", "cluster DNS", "cannot parse kubectl output: "+err.Error(), "")
+		} else {
+			ready := 0
+			for _, slice := range list.Items {
+				for _, endpoint := range slice.Endpoints {
+					if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready {
+						ready++
+					}
+				}
+			}
+			if ready == 0 {
+				report.add(VerificationFail, "kubernetes.dns", "cluster DNS", "kube-dns has no ready endpoints", "kubectl -n kube-system get endpointslice -l k8s-app=kube-dns")
+			} else {
+				report.add(VerificationPass, "kubernetes.dns", "cluster DNS", fmt.Sprintf("%d ready endpoint(s)", ready), "")
+			}
+		}
+	}
+
+	m.verifyOptionalKubernetesAddons(report, cp, timeout)
+}
+
+func (m *Manager) verifyOptionalKubernetesAddons(report *VerificationReport, cp string, timeout time.Duration) {
+	out, err := m.diagnosticKubectl(cp, report.Distro, timeout, "get", "storageclass", "-o", "json")
+	if err != nil {
+		report.add(VerificationFail, "storage.default-class", "default storage", compactError(err), "kubectl get storageclass")
+	} else {
+		var list kubeStorageClassList
+		if err := json.Unmarshal([]byte(out), &list); err != nil {
+			report.add(VerificationFail, "storage.default-class", "default storage", "cannot parse kubectl output: "+err.Error(), "")
+		} else if len(list.Items) == 0 {
+			report.add(VerificationSkip, "storage.default-class", "default storage", "no StorageClass installed (--no-storage cluster)", "")
+		} else {
+			var defaults []string
+			for _, item := range list.Items {
+				if item.Metadata.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" ||
+					item.Metadata.Annotations["storageclass.beta.kubernetes.io/is-default-class"] == "true" {
+					defaults = append(defaults, item.Metadata.Name)
+				}
+			}
+			if len(defaults) == 0 {
+				report.add(VerificationWarn, "storage.default-class", "default storage", "StorageClass exists, but none is default", "kubectl get storageclass")
+			} else {
+				report.add(VerificationPass, "storage.default-class", "default storage", "default StorageClass: "+strings.Join(defaults, ", "), "")
+			}
+		}
+	}
+
+	out, err = m.diagnosticKubectl(cp, report.Distro, timeout, "get", "apiservice", "v1beta1.metrics.k8s.io", "--ignore-not-found", "-o", "json")
+	if err != nil {
+		report.add(VerificationWarn, "metrics.api", "metrics API", compactError(err), "kubectl get apiservice v1beta1.metrics.k8s.io")
+	} else if strings.TrimSpace(out) == "" {
+		report.add(VerificationSkip, "metrics.api", "metrics API", "not installed (--no-metrics cluster)", "")
+	} else {
+		var service kubeAPIService
+		if err := json.Unmarshal([]byte(out), &service); err != nil {
+			report.add(VerificationFail, "metrics.api", "metrics API", "cannot parse kubectl output: "+err.Error(), "")
+		} else if conditionTrue(service.Status.Conditions, "Available") {
+			report.add(VerificationPass, "metrics.api", "metrics API", "APIService is Available", "")
+		} else {
+			report.add(VerificationFail, "metrics.api", "metrics API", "APIService is not Available", "kubectl describe apiservice v1beta1.metrics.k8s.io")
+		}
+	}
+
+	out, err = m.diagnosticKubectl(cp, report.Distro, timeout, "get", "gateway", "kiac", "-n", "kiac-gateway", "--ignore-not-found", "-o", "json")
+	if err != nil {
+		report.add(VerificationWarn, "gateway.api", "Gateway API", compactError(err), "kubectl get gateway -A")
+	} else if strings.TrimSpace(out) == "" {
+		report.add(VerificationSkip, "gateway.api", "Gateway API", "built-in Gateway is not installed", "")
+	} else {
+		var gateway kubeGateway
+		if err := json.Unmarshal([]byte(out), &gateway); err != nil {
+			report.add(VerificationFail, "gateway.api", "Gateway API", "cannot parse kubectl output: "+err.Error(), "")
+		} else if len(gateway.Status.Addresses) == 0 || conditionFalse(gateway.Status.Conditions, "Programmed") {
+			report.add(VerificationFail, "gateway.api", "Gateway API", "Gateway kiac-gateway/kiac has no programmed address", "kubectl describe gateway -n kiac-gateway kiac")
+		} else {
+			report.add(VerificationPass, "gateway.api", "Gateway API", "Gateway address: "+gateway.Status.Addresses[0].Value, "")
+		}
+	}
+
+	out, err = m.diagnosticKubectl(cp, report.Distro, timeout, "get", "namespace", obsNamespace, "--ignore-not-found", "-o", "name")
+	if err != nil {
+		report.add(VerificationWarn, "observability.stack", "observability", compactError(err), "kubectl get pods -n "+obsNamespace)
+	} else if strings.TrimSpace(out) == "" {
+		report.add(VerificationSkip, "observability.stack", "observability", "built-in observability is not installed", "")
+	} else {
+		address, err := m.diagnosticKubectl(cp, report.Distro, timeout, "get", "service", "grafana", "-n", obsNamespace, "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}")
+		if err != nil || strings.TrimSpace(address) == "" {
+			report.add(VerificationFail, "observability.stack", "observability", "Grafana has no LoadBalancer address", "kubectl get pods,svc -n "+obsNamespace)
+		} else {
+			report.add(VerificationPass, "observability.stack", "observability", "Grafana: http://"+strings.TrimSpace(address)+":3000", "")
+		}
+	}
+}
+
+func (m *Manager) verifyNodeAddons(report *VerificationReport, infos []runtime.Info, cp string, timeout time.Duration) {
+	var installed, missing, unhealthy []string
+	for _, info := range infos {
+		if !strings.EqualFold(info.Status, "running") {
+			continue
+		}
+		if _, err := m.rt.ExecTimeout(info.Name, timeout, "test", "-x", edgeProxyNodePath); err != nil {
+			missing = append(missing, info.Name)
+			continue
+		}
+		installed = append(installed, info.Name)
+		active := `PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bin/aux:$PATH"; IPT="$(command -v iptables-legacy || command -v iptables)"; `
+		if report.Distro == "k3s" {
+			active += `found=; for p in /proc/[0-9]*; do [ "$(readlink "$p/exe" 2>/dev/null)" = "` + edgeProxyNodePath + `" ] && found=1 && break; done; [ -n "$found" ]; `
+		} else {
+			active += `systemctl is-active --quiet kiac-edge-proxy.service; `
+		}
+		active += `"$IPT" -w -t nat -C PREROUTING -j KIAC-EDGE && "$IPT" -w -t nat -C OUTPUT -j KIAC-EDGE-OUTPUT`
+		if _, err := m.rt.ExecTimeout(info.Name, timeout, "sh", "-ec", active); err != nil {
+			unhealthy = append(unhealthy, info.Name)
+		}
+	}
+	if len(installed) == 0 {
+		report.add(VerificationSkip, "network.edge-proxy", "edge proxy", "not installed (--no-edge-proxy cluster)", "")
+	} else if len(missing) > 0 || len(unhealthy) > 0 {
+		report.add(VerificationFail, "network.edge-proxy", "edge proxy",
+			joinProblems(problem("missing", missing), problem("process/rules unhealthy", unhealthy)),
+			"inspect /var/log/kiac-edge-proxy.log on the affected node")
+	} else {
+		report.add(VerificationPass, "network.edge-proxy", "edge proxy",
+			fmt.Sprintf("process and redirect rules healthy on %d node(s)", len(installed)), "")
+	}
+
+	if _, err := m.rt.ExecTimeout(cp, timeout, "test", "-x", kiacLBScriptPath); err != nil {
+		report.add(VerificationSkip, "network.load-balancer", "LoadBalancer controller", "not installed (--no-lb cluster)", "")
+		return
+	}
+	var err error
+	if report.Distro == "k3s" {
+		_, err = m.rt.ExecTimeout(cp, timeout, "sh", "-ec", `pid="$(cat `+kiacLBK3sSupervisorPID+` 2>/dev/null)"; [ -n "$pid" ] && kill -0 "$pid"`)
+	} else {
+		_, err = m.rt.ExecTimeout(cp, timeout, "systemctl", "is-active", "--quiet", "kiac-lb.service")
+	}
+	if err != nil {
+		report.add(VerificationFail, "network.load-balancer", "LoadBalancer controller", "controller process is not healthy", nodeLBLogHint(report.Distro, cp))
+		return
+	}
+	out, svcErr := m.diagnosticKubectl(cp, report.Distro, timeout, "get", "services", "-A", "-o", "json")
+	if svcErr != nil {
+		report.add(VerificationFail, "network.load-balancer", "LoadBalancer controller", compactError(svcErr), "kubectl get services -A")
+		return
+	}
+	var services kubeServiceList
+	if err := json.Unmarshal([]byte(out), &services); err != nil {
+		report.add(VerificationFail, "network.load-balancer", "LoadBalancer controller", "cannot parse kubectl output: "+err.Error(), "")
+		return
+	}
+	var pending []string
+	count := 0
+	for _, svc := range services.Items {
+		if svc.Spec.Type != "LoadBalancer" {
+			continue
+		}
+		count++
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			pending = append(pending, svc.Metadata.Namespace+"/"+svc.Metadata.Name)
+		}
+	}
+	if len(pending) > 0 {
+		report.add(VerificationFail, "network.load-balancer", "LoadBalancer controller", "pending Services: "+limitedList(pending, 6), nodeLBLogHint(report.Distro, cp))
+	} else {
+		report.add(VerificationPass, "network.load-balancer", "LoadBalancer controller", fmt.Sprintf("controller healthy; %d LoadBalancer Service(s) assigned", count), "")
+	}
+}
+
+func (m *Manager) diagnosticKubectl(cp, distro string, timeout time.Duration, args ...string) (string, error) {
+	base := []string{"kubectl", "--kubeconfig", adminConf}
+	if distro == "k3s" {
+		base = []string{"kubectl", "--kubeconfig", k3sKubeconfig}
+	}
+	return m.rt.ExecTimeout(cp, timeout, append(base, args...)...)
+}
+
+func distroFromNodes(infos []runtime.Info) string {
+	for _, info := range infos {
+		if strings.Contains(strings.ToLower(info.Image), "rancher/k3s") {
+			return "k3s"
+		}
+	}
+	return "kubeadm"
+}
+
+func nodeLogHint(distro string) string {
+	if distro == "k3s" {
+		return "cat /proc/1/status"
+	}
+	return "journalctl -u containerd -u kubelet --no-pager -n 100"
+}
+
+func nodeLBLogHint(distro, cp string) string {
+	if distro == "k3s" {
+		return fmt.Sprintf("inspect: container exec %s tail -100 %s", cp, kiacLBK3sLogPath)
+	}
+	return fmt.Sprintf("inspect: container exec %s journalctl -u kiac-lb --no-pager -n 100", cp)
+}
+
+func conditionTrue(conditions []kubeCondition, kind string) bool {
+	for _, condition := range conditions {
+		if condition.Type == kind {
+			return strings.EqualFold(condition.Status, "true")
+		}
+	}
+	return false
+}
+
+func conditionFalse(conditions []kubeCondition, kind string) bool {
+	for _, condition := range conditions {
+		if condition.Type == kind {
+			return strings.EqualFold(condition.Status, "false")
+		}
+	}
+	return false
+}
+
+func compactError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return compact(err.Error())
+}
+
+func compact(s string) string {
+	s = strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+	if len(s) > 300 {
+		return s[:297] + "..."
+	}
+	return s
+}
+
+func orUnknown(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "unknown"
+	}
+	return s
+}
+
+func problem(label string, values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return label + ": " + limitedList(values, 6)
+}
+
+func joinProblems(values ...string) string {
+	var nonempty []string
+	for _, value := range values {
+		if value != "" {
+			nonempty = append(nonempty, value)
+		}
+	}
+	return strings.Join(nonempty, "; ")
+}
+
+func limitedList(values []string, limit int) string {
+	if len(values) <= limit {
+		return strings.Join(values, ", ")
+	}
+	return strings.Join(values[:limit], ", ") + fmt.Sprintf(" (+%d more)", len(values)-limit)
+}
+
+type kubeMetadata struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	DeletionTimestamp string            `json:"deletionTimestamp"`
+	Annotations       map[string]string `json:"annotations"`
+}
+
+type kubeCondition struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+type kubeNodeList struct {
+	Items []struct {
+		Metadata kubeMetadata `json:"metadata"`
+		Status   struct {
+			Conditions []kubeCondition `json:"conditions"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+type kubePodList struct {
+	Items []struct {
+		Metadata kubeMetadata `json:"metadata"`
+		Status   struct {
+			Phase             string `json:"phase"`
+			ContainerStatuses []struct {
+				Ready bool `json:"ready"`
+			} `json:"containerStatuses"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+type kubeEndpointSliceList struct {
+	Items []struct {
+		Endpoints []struct {
+			Conditions struct {
+				Ready *bool `json:"ready"`
+			} `json:"conditions"`
+		} `json:"endpoints"`
+	} `json:"items"`
+}
+
+type kubeStorageClassList struct {
+	Items []struct {
+		Metadata kubeMetadata `json:"metadata"`
+	} `json:"items"`
+}
+
+type kubeAPIService struct {
+	Status struct {
+		Conditions []kubeCondition `json:"conditions"`
+	} `json:"status"`
+}
+
+type kubeGateway struct {
+	Status struct {
+		Addresses []struct {
+			Value string `json:"value"`
+		} `json:"addresses"`
+		Conditions []kubeCondition `json:"conditions"`
+	} `json:"status"`
+}
+
+type kubeServiceList struct {
+	Items []struct {
+		Metadata kubeMetadata `json:"metadata"`
+		Spec     struct {
+			Type string `json:"type"`
+		} `json:"spec"`
+		Status struct {
+			LoadBalancer struct {
+				Ingress []map[string]any `json:"ingress"`
+			} `json:"loadBalancer"`
+		} `json:"status"`
+	} `json:"items"`
+}

--- a/pkg/cluster/verify_test.go
+++ b/pkg/cluster/verify_test.go
@@ -1,0 +1,121 @@
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/saiyam1814/kiac/pkg/runtime"
+)
+
+func TestVerifyHealthyClusterData(t *testing.T) {
+	m := fakeVerificationManager(t)
+	report, err := m.Verify("dev", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]VerificationStatus{
+		"runtime.layout":        VerificationPass,
+		"runtime.nodes":         VerificationPass,
+		"kubernetes.api":        VerificationPass,
+		"kubernetes.nodes":      VerificationPass,
+		"kubernetes.pods":       VerificationPass,
+		"kubernetes.dns":        VerificationPass,
+		"storage.default-class": VerificationPass,
+		"metrics.api":           VerificationSkip,
+		"network.edge-proxy":    VerificationSkip,
+		"network.load-balancer": VerificationSkip,
+		"gateway.api":           VerificationSkip,
+		"observability.stack":   VerificationSkip,
+	}
+	for id, status := range want {
+		if got := verificationStatus(report, id); got != status {
+			t.Errorf("check %s = %s, want %s", id, got, status)
+		}
+	}
+	if report.Distro != "kubeadm" {
+		t.Errorf("distro = %q, want kubeadm", report.Distro)
+	}
+	if report.SchemaVersion != 1 || report.CheckedAt == "" || report.Duration == "" {
+		t.Errorf("report metadata incomplete: %+v", report)
+	}
+}
+
+func TestVerifyReportsUnhealthyPod(t *testing.T) {
+	t.Setenv("KIAC_TEST_POD_PHASE", "Pending")
+	report, err := fakeVerificationManager(t).Verify("dev", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := verificationStatus(report, "kubernetes.pods"); got != VerificationFail {
+		t.Fatalf("pod check = %s, want fail", got)
+	}
+	if report.FailureCount() == 0 {
+		t.Fatal("failed pod did not make report unhealthy")
+	}
+}
+
+func TestDistroFromNodes(t *testing.T) {
+	if got := distroFromNodes([]runtime.Info{{Image: "docker.io/rancher/k3s:v1.36.2-k3s1"}}); got != "k3s" {
+		t.Errorf("k3s image detected as %q", got)
+	}
+	if got := distroFromNodes([]runtime.Info{{Image: "docker.io/kindest/node:v1.36.1"}}); got != "kubeadm" {
+		t.Errorf("kindest image detected as %q", got)
+	}
+}
+
+func TestEndpointHostname(t *testing.T) {
+	for _, tc := range []struct {
+		endpoint string
+		want     string
+	}{
+		{"https://192.168.64.2:6443", "192.168.64.2"},
+		{"https://[fd00:10:244::2]:6443", "fd00:10:244::2"},
+		{"not a URL", ""},
+	} {
+		if got := endpointHostname(tc.endpoint); got != tc.want {
+			t.Errorf("endpointHostname(%q) = %q, want %q", tc.endpoint, got, tc.want)
+		}
+	}
+}
+
+func fakeVerificationManager(t *testing.T) *Manager {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "container")
+	script := `#!/bin/sh
+case "$*" in
+  "ls -a --format json")
+    printf '%s\n' '[{"configuration":{"id":"kiac-dev-control-plane","image":{"reference":"docker.io/kindest/node:v1.36.1"}},"status":{"state":"running","networks":[{"ipv4Address":"127.0.0.1/8"}]}}]'
+    ;;
+  *"get --raw=/readyz"*)
+    printf 'ok\n'
+    ;;
+  *"get nodes -o json"*)
+    printf '%s\n' '{"items":[{"metadata":{"name":"kiac-dev-control-plane"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
+    ;;
+  *"get pods -A -o json"*)
+    phase="${KIAC_TEST_POD_PHASE:-Running}"
+    printf '{"items":[{"metadata":{"name":"coredns","namespace":"kube-system"},"status":{"phase":"%s","containerStatuses":[{"ready":true}]}}]}\n' "$phase"
+    ;;
+  *"get endpointslice -n kube-system"*)
+    printf '%s\n' '{"items":[{"endpoints":[{"conditions":{"ready":true}}]}]}'
+    ;;
+  *"get storageclass -o json"*)
+    printf '%s\n' '{"items":[{"metadata":{"name":"standard","annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}]}'
+    ;;
+  *"get apiservice v1beta1.metrics.k8s.io"*|*"get gateway kiac -n kiac-gateway"*|*"get namespace kiac-observability"*)
+    ;;
+  *"test -x /usr/local/bin/kiac-edge-proxy"*|*"test -x /usr/local/bin/kiac-lb.sh"*)
+    exit 1
+    ;;
+  *)
+    ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &Manager{rt: &runtime.Client{Bin: bin}}
+}

--- a/pkg/runtime/container.go
+++ b/pkg/runtime/container.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -41,10 +42,21 @@ func (e *CommandError) Error() string {
 	return fmt.Sprintf("container %s failed: %v\n%s", strings.Join(e.Args, " "), e.Err, out)
 }
 
+// Unwrap lets callers distinguish timeouts and other execution failures
+// without losing the container command's captured diagnostic output.
+func (e *CommandError) Unwrap() error { return e.Err }
+
 func (c *Client) run(args ...string) (string, error) {
-	cmd := exec.Command(c.Bin, args...)
+	return c.runContext(context.Background(), args...)
+}
+
+func (c *Client) runContext(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, c.Bin, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
 		return string(out), &CommandError{Args: args, Output: string(out), Err: err}
 	}
 	return string(out), nil
@@ -77,6 +89,17 @@ func (c *Client) SystemRunning() bool {
 	}
 	low := strings.ToLower(out)
 	return !strings.Contains(low, "not running")
+}
+
+// SystemStatus returns the container service's human-readable status.
+// It is intended for diagnostics where the original output is useful.
+func (c *Client) SystemStatus(timeout time.Duration) (string, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return c.runContext(ctx, "system", "status")
 }
 
 // SystemStart starts the container API server.
@@ -170,6 +193,28 @@ func ValidateNodeRuntimeVersion(version string) error {
 func (c *Client) Exec(name string, command ...string) (string, error) {
 	args := append([]string{"exec", name}, command...)
 	return c.run(args...)
+}
+
+// ExecTimeout runs a bounded command inside a node. Diagnostic commands
+// use this instead of risking an indefinitely wedged container exec.
+func (c *Client) ExecTimeout(name string, timeout time.Duration, command ...string) (string, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	args := append([]string{"exec", name}, command...)
+	return c.runContext(ctx, args...)
+}
+
+// Logs returns a bounded snapshot of the node VM's console output.
+func (c *Client) Logs(name string, timeout time.Duration) (string, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return c.runContext(ctx, "logs", name)
 }
 
 // ExecStdin runs a command inside a node with r piped to stdin.

--- a/pkg/runtime/container_test.go
+++ b/pkg/runtime/container_test.go
@@ -1,11 +1,14 @@
 package runtime
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 // container CLI 0.x ls --format json shape (nested configuration object).
@@ -29,6 +32,21 @@ func TestParseListShapes(t *testing.T) {
 	}
 	if len(infos) != 1 || infos[0].Name != "kiac-dev-worker-1" || infos[0].Status != "stopped" {
 		t.Errorf("v1 shape parsed wrong: %+v", infos)
+	}
+}
+
+func TestExecTimeout(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "container")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexec sleep 5\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, err := (&Client{Bin: bin}).ExecTimeout("node", 25*time.Millisecond, "true")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ExecTimeout error = %v, want context deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("ExecTimeout took %s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add read-only `kiac verify cluster` checks for VM/node health, Kubernetes readiness, DNS, storage, metrics, edge-proxy rules, LoadBalancer assignment, Gateway API, observability, and host API reachability
- add stable JSON output with nonzero exit status for required failures
- add `kiac support bundle` with bounded commands, per-command timeouts, credential redaction, source-level secret exclusions, mode-0600 archives, and no-overwrite behavior
- document both troubleshooting workflows

## Security boundaries
The bundle does not collect kubeconfigs, Kubernetes Secrets, raw container inspection, process environments, application workload logs, or edge-proxy credential files. Remaining text is redacted and capped at 512 KiB per file.

## Validation
- `make ci`
- exact unit/race coverage for timeout cancellation, report classification, unhealthy pods, redaction, UTF-8-safe truncation, archive modes and ordering, unsafe paths, and no-overwrite behavior
- live `verify` on 2-node and 3-node kubeadm clusters: both healthy in about 2 seconds
- live stopped-cluster verification: one required failure plus actionable resume hint
- live 3-node support bundle: 37 files, 95 KB compressed, mode 0600, zero collection warnings
- extracted bundle audit found no kubeconfig credential fields, private keys, bearer tokens, k3s tokens, or unredacted token/password assignments
- live stopped-cluster bundle: 8 files, completed without starting or changing the cluster
