### PR TITLE
release: harden artifact supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -22,6 +22,9 @@ on:
 
 permissions:
   contents: write # release asset upload on tag builds
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 env:
   # 6.12.28 matches the Kata default kernel `container` 1.0.0 boots
@@ -39,7 +42,10 @@ jobs:
   build:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Fetch pinned base config from apple/containerization
         run: |
@@ -62,7 +68,7 @@ jobs:
           docker run --rm \
             -v "$PWD:/w" -w /w \
             -e KERNEL_VERSION="${KERNEL_VERSION}" \
-            ubuntu:24.04 bash -euxc '
+            ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea bash -euxc '
               export DEBIAN_FRONTEND=noninteractive
               apt-get update
               apt-get install -y --no-install-recommends \
@@ -88,13 +94,20 @@ jobs:
           sha256sum "kiac-kernel-${KERNEL_VERSION}-full" \
             | tee "kiac-kernel-${KERNEL_VERSION}-full.sha256"
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload kernel build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kiac-kernel-${{ env.KERNEL_VERSION }}-full
           path: |
             kiac-kernel-${{ env.KERNEL_VERSION }}-full
             kiac-kernel-${{ env.KERNEL_VERSION }}-full.sha256
           if-no-files-found: error
+
+      - name: Attest kernel provenance
+        if: startsWith(github.ref, 'refs/tags/kernel-v')
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: kiac-kernel-${{ env.KERNEL_VERSION }}-full.sha256
 
       # Tag builds publish release assets; pkg/cluster/kernel.go pins
       # the sha256 printed above and downloads from this release.
@@ -104,8 +117,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
-          gh release create "$tag" --notes "kiac full node kernel ${KERNEL_VERSION} (arm64 Image, monolithic, CNI-ready)" || true
-          gh release upload "$tag" \
-            "kiac-kernel-${KERNEL_VERSION}-full" \
-            "kiac-kernel-${KERNEL_VERSION}-full.sha256" \
-            --clobber
+          if draft="$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            if [[ "${draft}" != "true" ]]; then
+              echo "release ${tag} is already published; immutable assets cannot be replaced" >&2
+              exit 1
+            fi
+            gh release upload "$tag" \
+              "kiac-kernel-${KERNEL_VERSION}-full" \
+              "kiac-kernel-${KERNEL_VERSION}-full.sha256" \
+              --clobber
+          else
+            gh release create "$tag" \
+              --draft \
+              --verify-tag \
+              --title "$tag" \
+              --notes "kiac full node kernel ${KERNEL_VERSION} (arm64 Image, monolithic, CNI-ready)" \
+              "kiac-kernel-${KERNEL_VERSION}-full" \
+              "kiac-kernel-${KERNEL_VERSION}-full.sha256"
+          fi
+          gh release edit "$tag" --draft=false --verify-tag

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,12 +22,21 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs
+
       - id: deployment
-        uses: actions/deploy-pages@v4
+        name: Deploy Pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25.12"
+          cache: true
+
+      - name: Validate release tag and source
+        shell: bash
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "release tag must be valid SemVer prefixed with v: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "release commit ${GITHUB_SHA} is not on main" >&2
+            exit 1
+          fi
+
+      - name: Configure Homebrew tap deploy key
+        shell: bash
+        env:
+          HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+        run: |
+          if [[ -z "${HOMEBREW_TAP_DEPLOY_KEY}" ]]; then
+            echo "HOMEBREW_TAP_DEPLOY_KEY is not configured" >&2
+            exit 1
+          fi
+          key_path="${RUNNER_TEMP}/homebrew-tap-deploy-key"
+          umask 077
+          printf '%s\n' "${HOMEBREW_TAP_DEPLOY_KEY}" > "${key_path}"
+          echo "HOMEBREW_TAP_DEPLOY_KEY_PATH=${key_path}" >> "${GITHUB_ENV}"
+          echo "GIT_SSH_COMMAND=ssh -i ${key_path} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -F /dev/null" >> "${GITHUB_ENV}"
+
+      - name: Test release source
+        run: make ci
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.50.0
+
+      - name: Build and upload draft release
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: v2.17.1
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_DEPLOY_KEY_PATH: ${{ env.HOMEBREW_TAP_DEPLOY_KEY_PATH }}
+
+      - name: Verify release artifacts
+        id: artifacts
+        shell: bash
+        run: |
+          (cd dist && sha256sum --check checksums.txt)
+          archive="$(find dist -maxdepth 1 -type f -name '*.tar.gz' -print -quit)"
+          if [[ -z "${archive}" || ! -f "${archive}.sbom.json" ]]; then
+            echo "release archive or its SBOM is missing" >&2
+            exit 1
+          fi
+          echo "archive=${archive}" >> "${GITHUB_OUTPUT}"
+          echo "sbom=${archive}.sbom.json" >> "${GITHUB_OUTPUT}"
+
+      - name: Attest release provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: dist/checksums.txt
+
+      - name: Attest archive SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: ${{ steps.artifacts.outputs.archive }}
+          sbom-path: ${{ steps.artifacts.outputs.sbom }}
+
+      - name: Complete Homebrew formula-to-cask migration
+        shell: bash
+        run: |
+          tap_dir="${RUNNER_TEMP}/homebrew-tap"
+          git clone --depth 1 git@github.com:saiyam1814/homebrew-tap.git "${tap_dir}"
+          test -f "${tap_dir}/Casks/kiac.rb"
+          rm -f "${tap_dir}/kiac.rb" "${tap_dir}/Formula/kiac.rb"
+          if [[ -f "${tap_dir}/tap_migrations.json" ]]; then
+            jq '. + {"kiac": "kiac"}' "${tap_dir}/tap_migrations.json" > "${tap_dir}/tap_migrations.json.tmp"
+            mv "${tap_dir}/tap_migrations.json.tmp" "${tap_dir}/tap_migrations.json"
+          else
+            printf '{\n  "kiac": "kiac"\n}\n' > "${tap_dir}/tap_migrations.json"
+          fi
+          git -C "${tap_dir}" add --all
+          if ! git -C "${tap_dir}" diff --cached --quiet; then
+            git -C "${tap_dir}" -c user.name='kiac release bot' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m 'kiac: migrate formula to cask'
+            git -C "${tap_dir}" push origin HEAD:main
+          fi
+
+      - name: Publish immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --verify-tag
+
+      - name: Remove deploy key
+        if: always()
+        run: rm -f "${HOMEBREW_TAP_DEPLOY_KEY_PATH}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,10 +22,23 @@ archives:
 checksum:
   name_template: checksums.txt
 
+sboms:
+  - artifacts: archive
+
 homebrew_casks:
-  - repository:
+  - directory: Casks
+    repository:
       owner: saiyam1814
       name: homebrew-tap
+      branch: main
+      git:
+        url: git@github.com:saiyam1814/homebrew-tap.git
+        private_key: "{{ .Env.HOMEBREW_TAP_DEPLOY_KEY_PATH }}"
+    commit_author:
+      name: kiac release bot
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    url:
+      verified: github.com/saiyam1814/kiac/
     homepage: https://github.com/saiyam1814/kiac
     description: "Kubernetes in Apple Containers - every node is its own lightweight VM"
     license: MIT

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 ```bash
-brew install saiyam1814/tap/kiac
+brew install --cask saiyam1814/tap/kiac
 kiac create cluster --workers 2
 ```
 
@@ -98,7 +98,7 @@ Containers are great for packaging software, and kiac depends on them. The point
 ### Install
 
 ```bash
-brew install saiyam1814/tap/kiac
+brew install --cask saiyam1814/tap/kiac
 ```
 
 <details>
@@ -112,6 +112,17 @@ go install github.com/saiyam1814/kiac@latest
 git clone https://github.com/saiyam1814/kiac && cd kiac && make build
 ```
 </details>
+
+### Verify a release
+
+Every release includes SHA-256 checksums and an SPDX SBOM. GitHub also signs build provenance for each artifact, and published releases are immutable.
+
+```bash
+gh release download vX.Y.Z --repo saiyam1814/kiac --dir kiac-release
+(cd kiac-release && shasum -a 256 -c checksums.txt)
+gh attestation verify kiac-release/kiac_X.Y.Z_darwin_arm64.tar.gz --repo saiyam1814/kiac
+gh release verify vX.Y.Z --repo saiyam1814/kiac
+```
 
 ### Create your first cluster
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,40 @@
+# Releasing kiac
+
+Application releases are built only from SemVer tags on `main`. The release workflow:
+
+1. Runs the full source CI suite.
+2. Builds the darwin/arm64 archive with GoReleaser.
+3. Generates an SPDX SBOM and SHA-256 checksums.
+4. Uploads everything to a draft GitHub release.
+5. Creates GitHub/Sigstore provenance and SBOM attestations.
+6. Updates the Homebrew tap with its repository-scoped deploy key.
+7. Publishes the release only after every preceding step succeeds.
+
+Published releases and their tags are immutable. If a draft release fails partway through, fix the cause and rerun the failed workflow before publishing it. Never replace an artifact under an existing version; create a new patch release.
+
+## One-time repository setup
+
+The `HOMEBREW_TAP_DEPLOY_KEY` Actions secret contains an unencrypted SSH private key. Its public half must be a write-enabled deploy key on `saiyam1814/homebrew-tap`. It has no access to any other repository.
+
+## Create a release
+
+Start from a clean, current `main`, choose the next SemVer version, and push an annotated tag:
+
+```bash
+git switch main
+git pull --ff-only
+make ci
+git tag -a vX.Y.Z -m "kiac vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+After the workflow succeeds, verify both the artifact provenance and GitHub's immutable release attestation:
+
+```bash
+gh release download vX.Y.Z --repo saiyam1814/kiac --dir kiac-release
+(cd kiac-release && shasum -a 256 -c checksums.txt)
+gh attestation verify kiac-release/kiac_X.Y.Z_darwin_arm64.tar.gz --repo saiyam1814/kiac
+gh release verify vX.Y.Z --repo saiyam1814/kiac
+```
+
+Kernel releases use `kernel-v*` tags and follow the same draft-first publication rule. After publishing a new kernel, update its SHA-256 pin in `pkg/cluster/kernel.go` through a normal pull request.


### PR DESCRIPTION
## Summary
- add a tag-driven, draft-first GoReleaser workflow with SPDX SBOMs and GitHub/Sigstore attestations
- migrate Homebrew publishing to a least-privilege deploy key and complete the formula-to-cask migration during release
- pin every workflow action and the kernel build image; make kernel releases immutable-ready
- add monthly grouped Dependabot updates and release verification docs

## Validation
- `make ci`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- GoReleaser v2.17.1 `check`
- GoReleaser v2.17.1 snapshot with Syft v1.50.0
- generated SPDX 2.3 SBOM, checksums, and Homebrew cask inspected
- generated cask passes `ruby -c`

## Repository setup
- installed a write-enabled deploy key scoped only to `saiyam1814/homebrew-tap`
- stored its private half as `HOMEBREW_TAP_DEPLOY_KEY` in this repository
- created the `dependencies` label for Dependabot