### PR TITLE
docs: avoid stale release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ kiac create cluster --name dev --workers 2   # 1 control plane + 2 workers
 ```
 
 ```text
-⬢ kiac v0.3.0 · Kubernetes in Apple Containers
+⬢ kiac · Kubernetes in Apple Containers
  ✓ Preflight checks (0.3s)
  ✓ Pulling node image kindest/node:v1.36.1 (8.4s)
  ✓ Booting 3 node VM(s) (9.8s)

--- a/docs/index.html
+++ b/docs/index.html
@@ -189,7 +189,7 @@
 </nav>
 
 <div class="hero">
-  <div class="pill">v0.3.0 · Built on apple/container 1.0</div>
+  <div class="pill">Latest release · Built on apple/container</div>
   <h1>Kubernetes.<br><span class="grad">Every node, its own VM.</span></h1>
   <p class="sub">Local clusters on Apple silicon where each node boots in its own lightweight virtual machine. Run Cilium and eBPF on a Mac. Get a k3s cluster in about 30 seconds. Keep your clusters across reboots. Storage, metrics, and LoadBalancer included.</p>
   <div class="cta-row">
@@ -313,7 +313,7 @@
 <script>
 const lines = [
   ['', '<span class="d">$</span> <span class="b">kiac create cluster --name dev --workers 2</span>'],
-  [400, '<span class="o">⬢ kiac</span> <span class="d">v0.3.0 · Kubernetes in Apple Containers</span>'],
+  [400, '<span class="o">⬢ kiac</span> <span class="d">· Kubernetes in Apple Containers</span>'],
   [600, ' <span class="ok">✓</span> Preflight checks <span class="d">(0.3s)</span>'],
   [900, ' <span class="ok">✓</span> Pulling node image kindest/node:v1.36.1 <span class="d">(4.6s)</span>'],
   [1500, ' <span class="ok">✓</span> Booting 3 node VM(s) <span class="d">(6.8s)</span>'],


### PR DESCRIPTION
## Summary

- make the website release pill version-neutral
- remove the hard-coded v0.3.0 from README and terminal demos

This keeps the public docs accurate across future releases without coupling documentation commits to the release workflow.

## Validation

- `git diff --check`
- confirmed no v0.3.0 references remain in README or the website