### PR TITLE
docs: add stacked kiac logo

### DIFF
--- a/assets/logo-stacked.svg
+++ b/assets/logo-stacked.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 440" width="480" height="440" role="img" aria-labelledby="title desc">
+  <title id="title">kiac</title>
+  <desc id="desc">Kubernetes in Apple Containers</desc>
+  <defs>
+    <linearGradient id="kiac-hex" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4F8BF0"/>
+      <stop offset="1" stop-color="#2D5FD0"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(78 0) scale(1.35)">
+    <path d="M120 30 L198 75 L198 165 L120 210 L42 165 L42 75 Z"
+          fill="url(#kiac-hex)" stroke="url(#kiac-hex)" stroke-width="20" stroke-linejoin="round"/>
+    <g stroke="#FFFFFF" stroke-width="6" stroke-linecap="round" opacity="0.55">
+      <line x1="120" y1="88" x2="88" y2="150"/>
+      <line x1="120" y1="88" x2="152" y2="150"/>
+      <line x1="88" y1="150" x2="152" y2="150"/>
+    </g>
+    <circle cx="88" cy="150" r="13" fill="#FFFFFF"/>
+    <circle cx="152" cy="150" r="13" fill="#FFFFFF"/>
+    <circle cx="120" cy="88" r="17" fill="#FFFFFF"/>
+    <circle cx="120" cy="88" r="7" fill="#2D5FD0"/>
+  </g>
+  <text x="240" y="405" text-anchor="middle"
+        font-family="Helvetica Neue, Helvetica, Arial, sans-serif"
+        font-size="112" font-weight="800" letter-spacing="0" fill="#16202E">kiac</text>
+</svg>


### PR DESCRIPTION
## Summary

- add a transparent stacked kiac wordmark for catalog and Landscape use
- preserve the existing brand colors and node topology mark
- keep the project name legible at small tile sizes

## Verification

- `xmllint --noout assets/logo-stacked.svg`
- rendered at 960x880 and 300x275 with librsvg
- `make ci`