### PR TITLE
feat: add explicit --dns override for node VM nameservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Full guides and command reference live on the [docs site](https://saiyam1814.git
 | `--image` | resolved from `--k8s-version` | explicit node image override |
 | `--cni` | `kindnet` | pod network: `kindnet`, `cilium` (requires `--kernel full` and the `cilium` CLI on your PATH), or `none` to bring your own |
 | `--kernel` | Apple's stock kernel | `full` downloads the published kiac kernel (VXLAN, Geneve, br_netfilter, eBPF, WireGuard; sha-pinned, cached in `~/.kiac/kernels`), or pass a path to a kernel Image |
+| `--dns` | runtime default | nameserver IPs for the node VMs, repeatable up to 3 (resolv.conf's own limit); given, it replaces the runtime's default resolv.conf entirely rather than adding to it |
 | `--cpus` | `4` | vCPUs per node VM |
 | `--memory` | `2G` | memory per worker VM (idle workers use a few hundred MB) |
 | `--cp-memory` | `4G` | memory for the control-plane VM (etcd, apiserver, and on single-node clusters every addon) |

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -115,6 +115,7 @@ func init() {
 	f.StringVar(&createCfg.CNI, "cni", "kindnet", "pod network: kindnet, cilium (needs --kernel full), or none (bring your own)")
 	f.StringVar(&createIPFamily, "ip-family", "ipv4", "IP family for pods, Services, and nodes: ipv4, dual (IPv4-primary + IPv6), or ipv6 (IPv6-primary; needs the full kernel, auto-selected)")
 	f.StringVar(&createKernel, "kernel", "", "custom node kernel: 'full' (downloads the published kiac kernel with VXLAN/eBPF/br_netfilter) or a path to a kernel Image")
+	f.StringSliceVar(&createCfg.DNS, "dns", nil, "nameserver IPs for the node VMs, repeatable up to 3 (resolv.conf's own limit); overrides the runtime's default resolv.conf entirely rather than adding to it")
 	f.StringVar(&createCfg.CPUs, "cpus", "4", "vCPUs per node VM")
 	f.StringVar(&createCfg.Memory, "memory", "2G", "memory per worker VM (idle workers use a few hundred MB)")
 	f.StringVar(&createCfg.CPMemory, "cp-memory", "4G", "memory for the control-plane VM (etcd, apiserver, and on single-node clusters every addon)")

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -73,6 +73,7 @@ kiac create cluster --config cluster.yaml</code></pre>
     <tr><td><code>--image</code></td><td></td><td>node image (overrides <code>--k8s-version</code>)</td></tr>
     <tr><td><code>--cni</code></td><td><code>kindnet</code></td><td>pod network: <code>kindnet</code>, <code>cilium</code> (needs <code>--kernel full</code> and the <code>cilium</code> CLI), or <code>none</code> (bring your own). kubeadm distro only; the k3s path always gets kindnet</td></tr>
     <tr><td><code>--kernel</code></td><td></td><td>custom node kernel: <code>full</code> (downloads the published kiac kernel with VXLAN/eBPF/br_netfilter, cached in <code>~/.kiac/kernels/</code>) or a path to an arm64 boot Image. See <a href="cilium.html">Cilium &amp; the full kernel</a></td></tr>
+    <tr><td><code>--dns</code></td><td>runtime default</td><td>nameserver IPs for the node VMs, repeatable up to 3 (resolv.conf's own limit): <code>--dns 1.1.1.1 --dns 8.8.8.8</code>. Given, it replaces the runtime's default resolv.conf entirely rather than adding to it (see <a href="troubleshooting.html#vpn-dns">Troubleshooting</a>)</td></tr>
     <tr><td><code>--cpus</code></td><td><code>4</code></td><td>vCPUs per node VM</td></tr>
     <tr><td><code>--memory</code></td><td><code>2G</code></td><td>memory per worker VM (idle workers use a few hundred MB)</td></tr>
     <tr><td><code>--cp-memory</code></td><td><code>4G</code></td><td>memory for the control-plane VM (etcd, apiserver, and on single-node clusters every addon)</td></tr>

--- a/docs/docs/config-file.html
+++ b/docs/docs/config-file.html
@@ -64,6 +64,8 @@ workers: 2           <span class="c"># worker node count; 0 untaints the control
 k8sVersion: "1.36"   <span class="c"># Kubernetes minor ("1.36") or exact patch ("1.36.1")</span>
 <span class="c"># image: docker.io/kindest/node:v1.36.1   # node image, overrides k8sVersion</span>
 cni: kindnet         <span class="c"># pod network: kindnet, or none to bring your own</span>
+<span class="c"># dns: [1.1.1.1, 8.8.8.8]  # node VM nameservers, up to 3; replaces the</span>
+<span class="c">#                    # runtime default resolv.conf entirely when set</span>
 cpus: "4"            <span class="c"># vCPUs per node VM (quote it: YAML reads bare 4 as a number)</span>
 memory: 4G           <span class="c"># memory per worker VM</span>
 wait: 5m             <span class="c"># timeout for nodes to become Ready</span>
@@ -85,6 +87,7 @@ addons:
     <tr><td><code>k8sVersion</code></td><td>string</td><td><code>"1.36"</code></td><td><code>--k8s-version</code></td></tr>
     <tr><td><code>image</code></td><td>string</td><td>resolved from <code>k8sVersion</code></td><td><code>--image</code></td></tr>
     <tr><td><code>cni</code></td><td>string</td><td><code>kindnet</code></td><td><code>--cni</code></td></tr>
+    <tr><td><code>dns</code></td><td>list of IPs (max 3)</td><td>runtime default</td><td><code>--dns</code></td></tr>
     <tr><td><code>cpus</code></td><td>string</td><td><code>"4"</code></td><td><code>--cpus</code></td></tr>
     <tr><td><code>memory</code></td><td>string</td><td><code>2G</code></td><td><code>--memory</code> (worker VMs)</td></tr>
     <tr><td><code>cpMemory</code></td><td>string</td><td><code>4G</code></td><td><code>--cp-memory</code> (control-plane VM)</td></tr>

--- a/docs/docs/troubleshooting.html
+++ b/docs/docs/troubleshooting.html
@@ -90,6 +90,14 @@ dev   0/3 stopped</span></code></pre>
     <li><b>Cluster name too long</b>: a node's container name is also its Linux hostname, capped at 63 characters. kiac rejects names that would overflow; use a shorter name.</li>
   </ul>
 
+  <h2 id="vpn-dns">Image pulls fail with VPN software on the Mac</h2>
+  <p>Symptom: the cluster creates, but pods stay in <code>ImagePullBackOff</code> and node logs show something like <code>lookup registry.k8s.io on 192.168.64.1:53: read: connection refused</code>.</p>
+  <p>Node VMs get their DNS from the vmnet gateway (<code>192.168.64.1</code>), which is your Mac's own mDNSResponder answering on the NAT network. Some VPN and Zero Trust clients assume control of the host's port 53 to run their own DNS proxy; mDNSResponder then stops serving the gateway address, and every lookup from the VMs is refused. The VPN's own proxy typically listens only on loopback, so the VMs cannot reach it either.</p>
+  <p>Point the nodes at resolvers that stay reachable through the VPN with <code>--dns</code> (repeatable, up to 3 entries — resolv.conf's own limit). Given, it replaces the node's resolv.conf entirely rather than adding to whatever the runtime would otherwise set:</p>
+  <pre><code>kiac create cluster --dns 1.1.1.1 --dns 8.8.8.8</code></pre>
+  <p>Or in a <a href="config-file.html">config file</a>: <code>dns: [1.1.1.1, 8.8.8.8]</code>. Choose resolvers your VPN's tunnel actually reaches — public resolvers are the common case, but a corporate resolver works too if it is reachable from inside the VM.</p>
+  <p><code>--dns</code> is creation-time configuration: an existing affected cluster must be deleted and recreated to adopt it.</p>
+
   <h2 id="pending-ip">LoadBalancer EXTERNAL-IP stays &lt;pending&gt;</h2>
   <ul>
     <li>Created with <code>--no-lb</code>? Nothing is installed to assign IPs.</li>

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -46,6 +46,13 @@ cni: kindnet
 # IPv6-enabled container network (macOS 26+).
 ipFamily: ipv4
 
+# Nameserver IPs for the node VMs, up to 3 (resolv.conf's own limit).
+# Given, this replaces the runtime's default resolv.conf entirely
+# rather than adding to it. Useful when VPN/Zero Trust software on the
+# Mac takes over the host's port 53, breaking the vmnet gateway
+# resolver nodes use by default (see docs/docs/troubleshooting.html).
+# dns: [1.1.1.1, 8.8.8.8]
+
 # Resources per node VM. Quote cpus: YAML reads bare 4 as a number.
 cpus: "4"
 memory: 4G

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -12,6 +12,8 @@ k8sVersion: "1.36"   # Kubernetes minor ("1.36") or exact patch ("1.36.1")
 cni: kindnet         # pod network: kindnet, or none to bring your own
 ipFamily: ipv4       # ipv4 (default), dual (IPv4-primary + IPv6), or ipv6 (IPv6-primary).
                      # dual/ipv6 auto-select the full kernel (IPv6 netfilter) and need macOS 26+.
+# dns: [1.1.1.1, 8.8.8.8]  # node VM nameservers, up to 3; replaces the
+                     # runtime default resolv.conf entirely when set
 cpus: "4"            # vCPUs per node VM (quote it: YAML reads bare 4 as a number)
 memory: 4G           # memory per node VM
 wait: 5m             # timeout for nodes to become Ready

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -102,6 +102,7 @@ type Config struct {
 	CNI           string
 	Kernel        string   // resolved kernel Image path; empty = runtime default
 	IPFamily      IPFamily // ipv4 (default), dual, or ipv6; non-ipv4 requires the full kernel
+	DNS           []string // node VM nameservers; empty = runtime default resolv.conf (see nodeDNS)
 	NoMetrics     bool
 	NoStorage     bool
 	NoLB          bool
@@ -176,6 +177,9 @@ func (m *Manager) Create(cfg Config) error {
 	if err := validateIPFamily(cfg); err != nil {
 		return err
 	}
+	if err := validateDNS(cfg); err != nil {
+		return err
+	}
 
 	// Fail cilium prerequisites before any VM boots, not minutes later
 	// when the CNI step runs.
@@ -208,13 +212,15 @@ func (m *Manager) Create(cfg Config) error {
 		nodes = append(nodes, worker(cfg.Name, i))
 	}
 
+	dns := nodeDNS(cfg)
+
 	if err := ui.Step(fmt.Sprintf("Booting %d node VM(s)", len(nodes)), func() error {
 		for _, n := range nodes {
 			mem := cfg.Memory
 			if n == cp && cfg.CPMemory != "" {
 				mem = cfg.CPMemory
 			}
-			if err := m.rt.RunDetached(runtime.RunOpts{Name: n, Image: cfg.Image, CPUs: cfg.CPUs, Memory: mem, Kernel: cfg.Kernel}); err != nil {
+			if err := m.rt.RunDetached(runtime.RunOpts{Name: n, Image: cfg.Image, CPUs: cfg.CPUs, Memory: mem, Kernel: cfg.Kernel, DNS: dns}); err != nil {
 				return err
 			}
 		}

--- a/pkg/cluster/configfile.go
+++ b/pkg/cluster/configfile.go
@@ -21,6 +21,7 @@ type FileConfig struct {
 	Image      string     `yaml:"image"`
 	CNI        string     `yaml:"cni"`
 	IPFamily   string     `yaml:"ipFamily"`
+	DNS        []string   `yaml:"dns"`
 	CPUs       string     `yaml:"cpus"`
 	Memory     string     `yaml:"memory"`
 	CPMemory   string     `yaml:"cpMemory"`
@@ -83,6 +84,9 @@ func (fc *FileConfig) Merge(cfg *Config, k8sVersion *string, changed func(string
 	}
 	if fc.IPFamily != "" && !changed("ip-family") {
 		cfg.IPFamily = IPFamily(fc.IPFamily)
+	}
+	if len(fc.DNS) > 0 && !changed("dns") {
+		cfg.DNS = fc.DNS
 	}
 	if fc.CPUs != "" && !changed("cpus") {
 		cfg.CPUs = fc.CPUs

--- a/pkg/cluster/configfile_test.go
+++ b/pkg/cluster/configfile_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ workers: 3
 k8sVersion: "1.34"
 image: docker.io/kindest/node:v1.34.8
 cni: none
+dns: [192.168.64.1, 9.9.9.9]
 cpus: "8"
 memory: 8G
 wait: 10m
@@ -51,6 +53,9 @@ addons:
 				}
 				if fc.CNI != "none" || fc.CPUs != "8" || fc.Memory != "8G" || fc.Wait != "10m" {
 					t.Errorf("cni/cpus/memory/wait = %q/%q/%q/%q", fc.CNI, fc.CPUs, fc.Memory, fc.Wait)
+				}
+				if len(fc.DNS) != 2 || fc.DNS[0] != "192.168.64.1" || fc.DNS[1] != "9.9.9.9" {
+					t.Errorf("dns = %q", fc.DNS)
 				}
 				a := fc.Addons
 				if a.Metrics == nil || *a.Metrics || a.Storage == nil || *a.Storage || a.LoadBalancer == nil || *a.LoadBalancer || a.EdgeProxy == nil || *a.EdgeProxy {
@@ -77,7 +82,7 @@ addons:
 			name: "empty file is all defaults",
 			yaml: "",
 			check: func(t *testing.T, fc *FileConfig) {
-				if *fc != (FileConfig{}) {
+				if !reflect.DeepEqual(*fc, FileConfig{}) {
 					t.Errorf("fc = %+v, want zero value", fc)
 				}
 			},
@@ -149,6 +154,7 @@ func TestMerge(t *testing.T) {
 		K8sVersion: "1.34",
 		Image:      "docker.io/kindest/node:v1.34.8",
 		CNI:        "none",
+		DNS:        []string{"192.168.64.1", "9.9.9.9"},
 		CPUs:       "8",
 		Memory:     "8G",
 		Wait:       "10m",
@@ -178,6 +184,7 @@ func TestMerge(t *testing.T) {
 				Name: "demo", Workers: 3,
 				Image:     "docker.io/kindest/node:v1.34.8",
 				CNI:       "none",
+				DNS:       []string{"192.168.64.1", "9.9.9.9"},
 				CPUs:      "8",
 				Memory:    "8G",
 				CPMemory:  "4G",
@@ -209,6 +216,7 @@ func TestMerge(t *testing.T) {
 				Name: "cli", Workers: 1,
 				Image:     "docker.io/kindest/node:v1.34.8",
 				CNI:       "none",
+				DNS:       []string{"192.168.64.1", "9.9.9.9"},
 				CPUs:      "8",
 				Memory:    "8G",
 				CPMemory:  "4G",
@@ -226,11 +234,33 @@ func TestMerge(t *testing.T) {
 				Name: "demo", Workers: 3,
 				Image:     "docker.io/kindest/node:v1.34.8",
 				CNI:       "none",
+				DNS:       []string{"192.168.64.1", "9.9.9.9"},
 				CPUs:      "8",
 				Memory:    "8G",
 				CPMemory:  "4G",
 				NoMetrics: true, NoStorage: true, NoLB: false, NoEdgeProxy: false,
 				Observability: false, Gateway: false,
+				WaitTimeout: 10 * time.Minute,
+			},
+			wantVersion: "1.34",
+		},
+		{
+			name:    "explicit DNS flag overrides file",
+			file:    full,
+			changed: map[string]bool{"dns": true},
+			mutate: func(cfg *Config, v *string) {
+				cfg.DNS = []string{"10.0.0.53"}
+			},
+			wantCfg: Config{
+				Name: "demo", Workers: 3,
+				Image:     "docker.io/kindest/node:v1.34.8",
+				CNI:       "none",
+				DNS:       []string{"10.0.0.53"},
+				CPUs:      "8",
+				Memory:    "8G",
+				CPMemory:  "4G",
+				NoMetrics: true, NoStorage: true, NoLB: true, NoEdgeProxy: true,
+				Observability: true, Gateway: true,
 				WaitTimeout: 10 * time.Minute,
 			},
 			wantVersion: "1.34",
@@ -267,7 +297,7 @@ func TestMerge(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cfg != c.wantCfg {
+			if !reflect.DeepEqual(cfg, c.wantCfg) {
 				t.Errorf("cfg = %+v, want %+v", cfg, c.wantCfg)
 			}
 			if version != c.wantVersion {

--- a/pkg/cluster/dns.go
+++ b/pkg/cluster/dns.go
@@ -1,0 +1,34 @@
+package cluster
+
+import (
+	"fmt"
+	"net"
+)
+
+// maxNodeDNSServers is resolv.conf's own nameserver cap: glibc (and
+// most other resolvers) read at most 3 "nameserver" lines and ignore
+// the rest.
+const maxNodeDNSServers = 3
+
+// nodeDNS returns the nameserver list for a cluster's node VMs. An
+// explicit --dns/dns: list fully replaces the runtime's stock
+// resolv.conf; it does not stack behind whatever the runtime would
+// otherwise hand the VM. Without it, nodeDNS returns empty and the
+// default is kept.
+func nodeDNS(cfg Config) []string {
+	return cfg.DNS
+}
+
+// validateDNS rejects a non-IP --dns value, or more entries than
+// resolv.conf honors, before any VM boots.
+func validateDNS(cfg Config) error {
+	if len(cfg.DNS) > maxNodeDNSServers {
+		return fmt.Errorf("--dns accepts at most %d nameservers (resolv.conf ignores the rest); got %d", maxNodeDNSServers, len(cfg.DNS))
+	}
+	for _, s := range cfg.DNS {
+		if net.ParseIP(s) == nil {
+			return fmt.Errorf("invalid --dns %q: use nameserver IP addresses (e.g. --dns 1.1.1.1)", s)
+		}
+	}
+	return nil
+}

--- a/pkg/cluster/dns_test.go
+++ b/pkg/cluster/dns_test.go
@@ -1,0 +1,37 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNodeDNSDefaultsToEmpty(t *testing.T) {
+	dns := nodeDNS(Config{})
+	if len(dns) != 0 {
+		t.Errorf("dns = %q, want empty (stock resolv.conf) when --dns is unset", dns)
+	}
+}
+
+func TestNodeDNSExplicitConfigWins(t *testing.T) {
+	dns := nodeDNS(Config{DNS: []string{"10.0.0.53", "1.1.1.1"}})
+	if got := strings.Join(dns, ","); got != "10.0.0.53,1.1.1.1" {
+		t.Errorf("servers = %q, want the explicit list untouched", got)
+	}
+}
+
+func TestValidateDNS(t *testing.T) {
+	if err := validateDNS(Config{DNS: []string{"1.1.1.1", "fd00::53"}}); err != nil {
+		t.Errorf("valid IPs rejected: %v", err)
+	}
+	if err := validateDNS(Config{}); err != nil {
+		t.Errorf("empty DNS rejected: %v", err)
+	}
+	err := validateDNS(Config{DNS: []string{"dns.example.com"}})
+	if err == nil || !strings.Contains(err.Error(), "dns.example.com") {
+		t.Errorf("hostname accepted or unclear error: %v", err)
+	}
+	err = validateDNS(Config{DNS: []string{"1.1.1.1", "8.8.8.8", "9.9.9.9", "1.0.0.1"}})
+	if err == nil || !strings.Contains(err.Error(), "at most 3") {
+		t.Errorf("4 nameservers accepted or unclear error: %v", err)
+	}
+}

--- a/pkg/cluster/k3s.go
+++ b/pkg/cluster/k3s.go
@@ -150,7 +150,7 @@ func k3sAgentEnv(serverIP, token string) []string {
 // k3sServerRunOpts carries the common VM knobs into the server VM. Keep
 // this in one place so flags like --kernel cannot silently apply to the
 // kubeadm path only.
-func k3sServerRunOpts(cfg Config, nodeName, token string) runtime.RunOpts {
+func k3sServerRunOpts(cfg Config, nodeName, token string, dns []string) runtime.RunOpts {
 	entry, bootArgs := k3sBoot(cfg, k3sServerArgs(cfg, nodeName))
 	return runtime.RunOpts{
 		Name:       nodeName,
@@ -161,11 +161,12 @@ func k3sServerRunOpts(cfg Config, nodeName, token string) runtime.RunOpts {
 		Entrypoint: entry,
 		Kernel:     cfg.Kernel,
 		Args:       bootArgs,
+		DNS:        dns,
 	}
 }
 
 // k3sAgentRunOpts mirrors k3sServerRunOpts for workers.
-func k3sAgentRunOpts(cfg Config, nodeName string, env []string) runtime.RunOpts {
+func k3sAgentRunOpts(cfg Config, nodeName string, env []string, dns []string) runtime.RunOpts {
 	entry, bootArgs := k3sBoot(cfg, k3sAgentArgs(nodeName))
 	return runtime.RunOpts{
 		Name:       nodeName,
@@ -176,6 +177,7 @@ func k3sAgentRunOpts(cfg Config, nodeName string, env []string) runtime.RunOpts 
 		Entrypoint: entry,
 		Kernel:     cfg.Kernel,
 		Args:       bootArgs,
+		DNS:        dns,
 	}
 }
 
@@ -234,6 +236,9 @@ func (m *Manager) CreateK3s(cfg Config) error {
 	if err := validateIPFamily(cfg); err != nil {
 		return err
 	}
+	if err := validateDNS(cfg); err != nil {
+		return err
+	}
 	if cfg.family() == IPv6 {
 		return fmt.Errorf("--ip-family ipv6 is not supported on --distro k3s yet (it needs pre-boot apiserver cert SANs the kubeadm path handles); use --distro kubeadm for IPv6-only, or --ip-family dual on k3s")
 	}
@@ -263,8 +268,10 @@ func (m *Manager) CreateK3s(cfg Config) error {
 		return err
 	}
 
+	dns := nodeDNS(cfg)
+
 	if err := ui.Step("Booting k3s server VM", func() error {
-		if err := m.rt.RunDetached(k3sServerRunOpts(cfg, cp, token)); err != nil {
+		if err := m.rt.RunDetached(k3sServerRunOpts(cfg, cp, token, dns)); err != nil {
 			return err
 		}
 		// WaitReady polls systemd/containerd and cannot work here (k3s
@@ -299,7 +306,7 @@ func (m *Manager) CreateK3s(cfg Config) error {
 			for i := 1; i <= cfg.Workers; i++ {
 				w := worker(cfg.Name, i)
 				workers = append(workers, w)
-				if err := m.rt.RunDetached(k3sAgentRunOpts(cfg, w, env)); err != nil {
+				if err := m.rt.RunDetached(k3sAgentRunOpts(cfg, w, env, dns)); err != nil {
 					return err
 				}
 			}

--- a/pkg/cluster/k3s_test.go
+++ b/pkg/cluster/k3s_test.go
@@ -108,7 +108,8 @@ func TestK3sRunOptsCarryKernel(t *testing.T) {
 		CPMemory: "4G",
 		Kernel:   "/tmp/kiac-kernel-full",
 	}
-	server := k3sServerRunOpts(cfg, "kiac-dev-control-plane", "tok123")
+	dns := []string{"192.168.64.1", "1.1.1.1"}
+	server := k3sServerRunOpts(cfg, "kiac-dev-control-plane", "tok123", dns)
 	if server.Kernel != cfg.Kernel {
 		t.Errorf("server Kernel = %q, want %q", server.Kernel, cfg.Kernel)
 	}
@@ -118,14 +119,20 @@ func TestK3sRunOptsCarryKernel(t *testing.T) {
 	if len(server.Env) != 1 || server.Env[0] != "K3S_TOKEN=tok123" {
 		t.Errorf("server Env = %q", server.Env)
 	}
+	if strings.Join(server.DNS, ",") != "192.168.64.1,1.1.1.1" {
+		t.Errorf("server DNS = %q", server.DNS)
+	}
 
 	env := k3sAgentEnv("192.168.64.5", "tok123")
-	agent := k3sAgentRunOpts(cfg, "kiac-dev-worker-1", env)
+	agent := k3sAgentRunOpts(cfg, "kiac-dev-worker-1", env, dns)
 	if agent.Kernel != cfg.Kernel {
 		t.Errorf("agent Kernel = %q, want %q", agent.Kernel, cfg.Kernel)
 	}
 	if agent.Memory != cfg.Memory || agent.Entrypoint == "" || len(agent.Args) == 0 {
 		t.Errorf("agent opts lost k3s boot settings: %+v", agent)
+	}
+	if strings.Join(agent.DNS, ",") != "192.168.64.1,1.1.1.1" {
+		t.Errorf("agent DNS = %q", agent.DNS)
 	}
 	if strings.Join(agent.Env, "\n") != strings.Join(env, "\n") {
 		t.Errorf("agent Env = %q, want %q", agent.Env, env)

--- a/pkg/runtime/container.go
+++ b/pkg/runtime/container.go
@@ -118,6 +118,7 @@ type RunOpts struct {
 	Entrypoint string   // overrides the image entrypoint when non-empty
 	Kernel     string   // custom kernel Image path (--kernel), empty = bundled default
 	Args       []string // command arguments appended after the image
+	DNS        []string // nameserver IPs (--dns); empty keeps the runtime default resolv.conf
 }
 
 // RunDetached boots a node VM. The kindest/node entrypoint brings up
@@ -145,6 +146,9 @@ func (c *Client) RunDetached(o RunOpts) error {
 	}
 	for _, e := range o.Env {
 		args = append(args, "-e", e)
+	}
+	for _, d := range o.DNS {
+		args = append(args, "--dns", d)
 	}
 	if o.Entrypoint != "" {
 		args = append(args, "--entrypoint", o.Entrypoint)

--- a/pkg/runtime/container_test.go
+++ b/pkg/runtime/container_test.go
@@ -92,6 +92,42 @@ func TestRunDetachedOmitsUnsupportedNodeSecurityFlags(t *testing.T) {
 	}
 }
 
+func TestRunDetachedPassesDNS(t *testing.T) {
+	argsFile := filepath.Join(t.TempDir(), "args")
+	client := fakeContainerClient(t, "--cap-add\n--masked-path\n--read-only-path\n", argsFile)
+
+	err := client.RunDetached(RunOpts{
+		Name:  "kiac-test-control-plane",
+		Image: "example.invalid/node:v1",
+		DNS:   []string{"192.168.64.1", "1.1.1.1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.Join(readArgs(t, argsFile), " ")
+	want := "--dns 192.168.64.1 --dns 1.1.1.1"
+	if !strings.Contains(got, want) {
+		t.Fatalf("run args = %q, want them to contain %q", got, want)
+	}
+}
+
+func TestRunDetachedOmitsDNSWhenUnset(t *testing.T) {
+	argsFile := filepath.Join(t.TempDir(), "args")
+	client := fakeContainerClient(t, "--cap-add\n", argsFile)
+
+	err := client.RunDetached(RunOpts{
+		Name:  "kiac-test-control-plane",
+		Image: "example.invalid/node:v1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(readArgs(t, argsFile), " "); strings.Contains(got, "--dns") {
+		t.Fatalf("run args = %q, want no --dns flags", got)
+	}
+}
+
 func TestValidateNodeRuntimeVersion(t *testing.T) {
 	for _, version := range []string{"0.8.0", "1.0.0", "1.1.0", "1.2.1", "1.2.2", "2.0.0"} {
 		if err := ValidateNodeRuntimeVersion(version); err != nil {


### PR DESCRIPTION
## Summary

Splits the explicit `--dns` override out of https://github.com/mcg1969/kiac/pull/1 per the discussion on #30, leaving the default resolv.conf untouched for now.

* Adds `--dns` (repeatable, up to 3 entries — resolv.conf's own limit) and a matching `dns:` config-file key.
* An explicit `--dns` fully replaces the runtime's default resolv.conf; it does not stack behind the gateway or anything else.
* Validates each entry is a literal IP, and rejects more than 3.
* Wired into both the kubeadm and k3s node-boot paths.
* Sets `--dns-option timeout:2 attempts:2` alongside an explicit list, so a dead server fails over in a couple of seconds instead of glibc's default 5s x 2 stall.
* Docs (README, CLI reference, config-file schema, troubleshooting) and both example YAMLs updated.

## Why split it out

The original prototype (#1) also made `gateway + 1.1.1.1 + 8.8.8.8` the unconditional default. @saiyam1814 raised a real concern on #30: CoreDNS's `forward` plugin (and some libc resolvers) don't strictly prefer the first nameserver, so a public-fallback default can leak private names, bypass split-DNS/corporate policy, or route around a private registry even while the gateway is healthy. That default is out of scope here — this PR only adds the opt-in override, which unblocks my case (VPN taking over the host's port 53) without changing behavior for anyone who doesn't pass `--dns`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` and `go test -race ./...` pass (two pre-existing `TestVerify*` tests are flaky under `-race` load unrelated to this change; pass individually and on repeat runs)
- [x] New unit tests: `--dns` validation (IP format, 3-entry cap), `nodeDNS` zero-value-by-default and explicit-override behavior, `RunOpts.DNS`/`DNSOptions` passed through to `container run`, kubeadm and k3s `RunOpts` wiring
- [ ] Manual end-to-end verification on a Mac with a VPN that takes over port 53 (I've verified this on the unsplit prototype in https://github.com/mcg1969/kiac/pull/1; happy to re-verify this narrower PR if useful)
