### PR TITLE
docs: add verified Portainer CE lab

### DIFF
--- a/docs/docs/cilium.html
+++ b/docs/docs/cilium.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/config-file.html
+++ b/docs/docs/config-file.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/contributing.html
+++ b/docs/docs/contributing.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/dashboard.html
+++ b/docs/docs/dashboard.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/gateway-api.html
+++ b/docs/docs/gateway-api.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a class="on" href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>
@@ -112,7 +115,7 @@ curl http://web.local/</code></pre>
 
   <div class="pn">
     <a href="observability.html"><span>Previous</span>Observability</a>
-    <a class="next" href="node-chaos.html"><span>Next</span>Node chaos</a>
+    <a class="next" href="labs.html"><span>Next</span>Integration labs</a>
   </div>
 </main>
 </div>

--- a/docs/docs/getting-started.html
+++ b/docs/docs/getting-started.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/k3s.html
+++ b/docs/docs/k3s.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/labs.html
+++ b/docs/docs/labs.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Integration labs - kiac docs</title>
+<meta name="description" content="Tested, repeatable labs for running Portainer CE, k8gb, Gateway API, observability, and OpenChoreo on kiac clusters.">
+<link rel="icon" type="image/svg+xml" href="../assets/logo-mark.svg">
+<link rel="stylesheet" href="docs.css">
+</head>
+<body>
+<input type="checkbox" id="menu">
+<header><div class="hin">
+  <a class="brand" href="../index.html"><img src="../assets/logo-mark.svg" alt="kiac"> kiac</a>
+  <a class="crumb" href="index.html">Docs</a>
+  <span class="spacer"></span>
+  <label for="menu" class="mtoggle">Menu</label>
+  <a class="gh" href="https://github.com/saiyam1814/kiac">GitHub</a>
+</div></header>
+<div class="wrap">
+<aside>
+  <div class="group"><div class="glabel">Start here</div>
+    <a href="index.html">Overview &amp; install</a>
+    <a href="getting-started.html">Getting started</a>
+  </div>
+  <div class="group"><div class="glabel">Core concepts</div>
+    <a href="networking.html">Networking</a>
+    <a href="storage-and-metrics.html">Storage &amp; metrics</a>
+    <a href="config-file.html">Config file</a>
+    <a href="cli-reference.html">CLI reference</a>
+  </div>
+  <div class="group"><div class="glabel">Distros &amp; kernels</div>
+    <a href="k3s.html">k3s distro</a>
+    <a href="cilium.html">Cilium &amp; the full kernel</a>
+  </div>
+  <div class="group"><div class="glabel">Built-in addons</div>
+    <a href="observability.html">Observability</a>
+    <a href="gateway-api.html">Gateway API</a>
+  </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a class="on" href="labs.html">Integration labs</a>
+  </div>
+  <div class="group"><div class="glabel">Day two</div>
+    <a href="node-chaos.html">Node chaos</a>
+    <a href="persistence.html">Reboots &amp; resume</a>
+    <a href="dashboard.html">Dashboard (kiac ui)</a>
+    <a href="troubleshooting.html">Troubleshooting</a>
+  </div>
+  <div class="group"><div class="glabel">Project</div>
+    <a href="contributing.html">Contributing</a>
+  </div>
+</aside>
+<main>
+  <div class="kicker">Hands-on</div>
+  <h1>Integration labs</h1>
+  <p class="lede">Repeatable workflows that exercise real traffic, storage, APIs, and failure paths on kiac clusters. Each lab includes verification and cleanup instead of stopping at installation.</p>
+
+  <h2 id="portainer">Portainer CE</h2>
+  <p>Run the license-free Portainer Community Edition on a small Kubernetes cluster. The lab pins the image and Helm chart, gives Portainer a persistent volume and LoadBalancer address, protects the generated admin password, and verifies authenticated API access.</p>
+  <pre><code>./examples/portainer.sh up
+./examples/portainer.sh verify
+./examples/portainer.sh cleanup</code></pre>
+  <p>Read the complete <a href="https://github.com/saiyam1814/kiac/blob/main/examples/portainer-lab.md">Portainer CE lab</a>. Portainer manages the Kubernetes cluster; it does not provide Docker Engine or Docker Compose compatibility for the macOS host.</p>
+
+  <h2 id="addons">Gateway API and observability</h2>
+  <p>These labs exercise kiac's built-in addons through their user-facing endpoints:</p>
+  <table>
+    <tr><th>Lab</th><th>What it proves</th></tr>
+    <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/gateway-api-lab.md">Gateway API</a></td><td>GatewayClass and Gateway readiness, HTTPRoute attachment, hostname and path matching, and traffic through the assigned LoadBalancer IP.</td></tr>
+    <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/observability-lab.md">Observability</a></td><td>Grafana access, Prometheus target discovery, application metrics, generated traffic, and metric queries.</td></tr>
+  </table>
+
+  <h2 id="multi-cluster">Multi-cluster and platform labs</h2>
+  <table>
+    <tr><th>Lab</th><th>What it proves</th></tr>
+    <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/k8gb-lab.md">k8gb failover</a></td><td>DNS delegation, two independent clusters, application health, regional failover, and failback.</td></tr>
+    <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/openchoreo-lab.md">OpenChoreo</a></td><td>A disposable platform cluster, component deployment, endpoint discovery, and cleanup.</td></tr>
+  </table>
+
+  <h2 id="operations">Failure and recovery labs</h2>
+  <table>
+    <tr><th>Lab</th><th>What it proves</th></tr>
+    <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/chaos-drill.md">Node chaos</a></td><td>Pod spreading, node loss, eviction, rescheduling, and node rejoin across workers.</td></tr>
+    <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/resume-drill.md">Reboot and resume</a></td><td>Cluster discovery after a host restart, coordinated resume, node readiness, and restored application traffic.</td></tr>
+  </table>
+
+  <div class="note"><b>Labs are intentionally optional</b>
+  Integrations stay outside the kiac binary unless they are part of the local-cluster foundation. This keeps startup fast and lets each workload declare its own security and resource cost.</div>
+
+  <div class="pn">
+    <a href="gateway-api.html"><span>Previous</span>Gateway API</a>
+    <a class="next" href="node-chaos.html"><span>Next</span>Node chaos</a>
+  </div>
+</main>
+</div>
+</body>
+</html>

--- a/docs/docs/networking.html
+++ b/docs/docs/networking.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/node-chaos.html
+++ b/docs/docs/node-chaos.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a class="on" href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>
@@ -89,7 +92,7 @@ kubectl get nodes -w    <span class="c"># watch it rejoin</span></code></pre>
   <p>The <a href="dashboard.html">dashboard</a> has per-node Stop/Start buttons that shell out to these same commands. For the whole-cluster outage a Mac reboot causes, see <a href="persistence.html">Reboots &amp; resume</a>.</p>
 
   <div class="pn">
-    <a href="gateway-api.html"><span>Previous</span>Gateway API</a>
+    <a href="labs.html"><span>Previous</span>Integration labs</a>
     <a class="next" href="persistence.html"><span>Next</span>Reboots &amp; resume</a>
   </div>
 </main>

--- a/docs/docs/observability.html
+++ b/docs/docs/observability.html
@@ -37,6 +37,9 @@
     <a class="on" href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/persistence.html
+++ b/docs/docs/persistence.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a class="on" href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/storage-and-metrics.html
+++ b/docs/docs/storage-and-metrics.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/docs/troubleshooting.html
+++ b/docs/docs/troubleshooting.html
@@ -37,6 +37,9 @@
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
   </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+  </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
     <a href="persistence.html">Reboots &amp; resume</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -182,6 +182,7 @@
       <a href="#why">Why</a>
       <a href="#features">Features</a>
       <a href="#install">Install</a>
+      <a href="docs/labs.html">Labs</a>
       <a href="docs/index.html">Docs</a>
       <a class="gh" href="https://github.com/saiyam1814/kiac">GitHub</a>
     </div>

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ kubectl apply -f https://raw.githubusercontent.com/saiyam1814/kiac/main/examples
 | [chaos-drill.md](chaos-drill.md) | Step-by-step node-failure drill: spread an app across workers, `kiac stop node`, watch eviction and reschedule, `kiac start node`, watch the rejoin. |
 | [resume-drill.md](resume-drill.md) | Reboot-survival drill: stop the container system, see `0/3 stopped` in `kiac get clusters`, bring it all back with `kiac resume`, curl the app again. |
 | [k8gb-lab.md](k8gb-lab.md) | Real DNS-based failover across two kiac clusters: lightweight edge DNS, delegated regional CoreDNS, HTTP traffic validation, failover, and failback. |
+| [portainer-lab.md](portainer-lab.md) | Portainer CE on a pinned Kubernetes 1.34 cluster: persistent data, a real LoadBalancer address, protected admin credentials, and authenticated API verification. |
 | [cluster.yaml](cluster.yaml) | Minimal `--config` file for `kiac create cluster`. |
 | [cluster-full.yaml](cluster-full.yaml) | `--config` file with every knob set and commented, all addons on including observability and gateway. |
 

--- a/examples/portainer-lab.md
+++ b/examples/portainer-lab.md
@@ -1,0 +1,115 @@
+# Portainer CE lab
+
+[Portainer](https://www.portainer.io/) is a web interface for managing containers and Kubernetes environments. This lab installs Portainer Community Edition inside a real kiac cluster and exposes it through kiac's built-in LoadBalancer.
+
+Portainer is an optional workload, not a kiac addon. The lab keeps Portainer's cluster-admin access, persistent data, credentials, and lifecycle explicit instead of adding them to every cluster.
+
+## What the lab builds
+
+```mermaid
+flowchart LR
+    B["Browser on macOS"] -->|"HTTPS :9443"| L["kiac-lb address"]
+    L --> P["Portainer CE 2.39.5"]
+    P --> A["Kubernetes API"]
+    P --> V["5 GiB local-path PVC"]
+```
+
+The script pins Portainer CE `2.39.5` LTS and Helm chart `239.5.0`. It creates a single-node Kubernetes `1.34` cluster because that version is in Portainer's validated Kubernetes range. The installation uses:
+
+- a real `type: LoadBalancer` Service assigned by `kiac-lb`;
+- a persistent volume from kiac's default StorageClass;
+- Portainer's official cluster-admin service account for local management;
+- a generated admin password stored mode `0600` under `~/.kiac/labs/portainer`;
+- the self-signed HTTPS endpoint on port `9443`.
+
+## Prerequisites
+
+```bash
+brew install --cask saiyam1814/tap/kiac
+brew install helm jq
+kiac doctor
+```
+
+Portainer CE does not require a license. The official images and chart support arm64.
+
+## Start the lab
+
+From a kiac checkout:
+
+```bash
+./examples/portainer.sh up
+```
+
+The first run creates `portainer-lab`, installs Portainer, waits for its Deployment and PVC, obtains the LoadBalancer IP, authenticates through the Portainer API, and registers the in-cluster Kubernetes environment. The current Portainer chart does not perform that final onboarding step automatically, so the lab makes it explicit and idempotent.
+
+At the end it prints output similar to:
+
+```text
+Portainer API version: 2.39.5
+managed environments: 1
+Kubernetes nodes through Portainer: 1
+UI: https://192.168.64.x:9443
+username: admin
+password file: /Users/you/.kiac/labs/portainer/portainer-lab/admin-password
+```
+
+The certificate is generated locally by Portainer, so the browser will show a self-signed certificate warning.
+
+## Verify it again
+
+```bash
+./examples/portainer.sh verify
+```
+
+This checks the actual user path rather than only reading Kubernetes status:
+
+1. The Portainer Deployment is available.
+2. Its persistent volume is `Bound`.
+3. `kiac-lb` assigned a reachable address.
+4. The HTTPS status endpoint reports the pinned Portainer version.
+5. The generated admin credentials obtain a JWT.
+6. The authenticated API lists the expected healthy local Kubernetes environment.
+7. Portainer's Kubernetes API proxy returns the cluster's nodes.
+
+Inspect the Kubernetes resources directly:
+
+```bash
+kubectl --context kiac-portainer-lab -n portainer get deploy,pod,svc,pvc
+```
+
+## Use an existing kiac cluster
+
+The default is intentionally isolated so cleanup can delete the whole lab safely. To install into an existing ready cluster:
+
+```bash
+KIAC_PORTAINER_CLUSTER=dev \
+KIAC_PORTAINER_USE_EXISTING=true \
+./examples/portainer.sh up
+```
+
+The script refuses to adopt an existing `portainer` namespace or Helm release. Its ownership markers let cleanup remove only resources created by this lab, never the existing cluster.
+
+To provide your own password without putting it in shell history:
+
+```bash
+PORTAINER_ADMIN_PASSWORD_FILE="$HOME/.config/portainer-lab-password" \
+./examples/portainer.sh up
+```
+
+The password must contain at least 12 characters.
+
+## Clean up
+
+```bash
+./examples/portainer.sh cleanup
+```
+
+For the default lab, this deletes the owned kiac cluster and its state directory. On an existing cluster, it removes only the owned Helm release and namespace, then deletes the local password copy.
+
+## Scope and security
+
+Portainer receives cluster-admin privileges because it manages the local Kubernetes environment. Use this lab only on a local development cluster, do not expose its LoadBalancer address beyond trusted networks, and use a trusted certificate plus external authentication for a shared deployment.
+
+This lab demonstrates Kubernetes management. It does not turn apple/container into Docker Engine, add Docker Compose compatibility, or make Portainer manage the macOS host runtime.
+
+See Portainer's [Kubernetes installation guide](https://docs.portainer.io/start/install-ce/server/kubernetes/baremetal) and [validated configurations](https://docs.portainer.io/start/requirements-and-prerequisites) for upstream details.

--- a/examples/portainer.sh
+++ b/examples/portainer.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# Run Portainer CE on a small kiac cluster and verify the real UI/API path.
+set -euo pipefail
+
+PORTAINER_VERSION="2.39.5"
+PORTAINER_CHART_VERSION="239.5.0"
+KUBERNETES_VERSION="1.34"
+
+CLUSTER_NAME="${KIAC_PORTAINER_CLUSTER:-portainer-lab}"
+CONTEXT="kiac-${CLUSTER_NAME}"
+NAMESPACE="portainer"
+RELEASE="portainer"
+STATE_DIR="${KIAC_PORTAINER_STATE_DIR:-${HOME}/.kiac/labs/portainer/${CLUSTER_NAME}}"
+PASSWORD_FILE="${STATE_DIR}/admin-password"
+VALUES_FILE="${STATE_DIR}/values.yaml"
+USE_EXISTING="${KIAC_PORTAINER_USE_EXISTING:-false}"
+
+info() { printf '    %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<EOF
+Usage: $0 [up|verify|cleanup]
+
+  up        Create a small Kubernetes 1.34 cluster and install Portainer CE
+  verify    Check the Deployment, PVC, LoadBalancer, status API, and login API
+  cleanup   Delete only the Portainer resources and cluster owned by this lab
+
+Environment:
+  KIAC_PORTAINER_CLUSTER=<name>         cluster name (default: portainer-lab)
+  KIAC_PORTAINER_USE_EXISTING=true      use an already-ready kiac context
+  KIAC_PORTAINER_STATE_DIR=<path>       ownership and credential state
+  PORTAINER_ADMIN_PASSWORD_FILE=<path>  seed the admin password from a file
+
+State: ${STATE_DIR}
+EOF
+}
+
+require_tools() {
+  local tool
+  for tool in kiac container kubectl helm curl jq openssl; do
+    command -v "${tool}" >/dev/null 2>&1 || fail "missing tool: ${tool}"
+  done
+}
+
+prepare_state() {
+  umask 077
+  mkdir -p "${STATE_DIR}"
+  chmod 0700 "${STATE_DIR}"
+}
+
+use_existing() {
+  case "${USE_EXISTING}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+container_exists() {
+  container inspect "$1" >/dev/null 2>&1
+}
+
+context_exists() {
+  kubectl config get-contexts -o name 2>/dev/null | grep -Fqx "$1"
+}
+
+context_ready() {
+  kubectl --context "$1" get --raw=/readyz >/dev/null 2>&1
+}
+
+ensure_cluster() {
+  local node="kiac-${CLUSTER_NAME}-control-plane"
+  local marker="${STATE_DIR}/cluster.created"
+
+  if context_ready "${CONTEXT}"; then
+    if [[ -f "${marker}" ]] || use_existing; then
+      info "using ready cluster ${CLUSTER_NAME}"
+      return
+    fi
+    fail "context ${CONTEXT} is live but is not owned by this lab; set KIAC_PORTAINER_USE_EXISTING=true to use it"
+  fi
+
+  use_existing && fail "KIAC_PORTAINER_USE_EXISTING=true, but context ${CONTEXT} is not ready"
+
+  if container_exists "${node}"; then
+    [[ -f "${marker}" ]] || fail "cluster ${CLUSTER_NAME} exists and is not owned by this lab"
+    step "Resuming lab cluster ${CLUSTER_NAME}"
+    kiac resume cluster --name "${CLUSTER_NAME}"
+    context_ready "${CONTEXT}" || fail "context ${CONTEXT} is not ready after resume"
+    return
+  fi
+
+  if context_exists "${CONTEXT}"; then
+    fail "stale context ${CONTEXT} exists without a running cluster; remove it or choose another name"
+  fi
+
+  step "Creating single-node Kubernetes ${KUBERNETES_VERSION} cluster"
+  touch "${marker}"
+  kiac create cluster \
+    --name "${CLUSTER_NAME}" \
+    --workers 0 \
+    --k8s-version "${KUBERNETES_VERSION}" \
+    --cpus "${KIAC_PORTAINER_CPUS:-4}" \
+    --cp-memory "${KIAC_PORTAINER_CP_MEMORY:-4G}" \
+    --no-metrics \
+    --wait 8m
+}
+
+ensure_namespace() {
+  local marker="${STATE_DIR}/namespace.created"
+
+  if kubectl --context "${CONTEXT}" get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+    [[ -f "${marker}" ]] || fail "namespace ${NAMESPACE} already exists and is not owned by this lab"
+    return
+  fi
+
+  touch "${marker}"
+  kubectl --context "${CONTEXT}" create namespace "${NAMESPACE}" >/dev/null
+}
+
+ensure_password() {
+  local source="${PORTAINER_ADMIN_PASSWORD_FILE:-}"
+  local password=""
+
+  if [[ ! -f "${PASSWORD_FILE}" ]]; then
+    if [[ -n "${source}" ]]; then
+      [[ -f "${source}" ]] || fail "PORTAINER_ADMIN_PASSWORD_FILE does not exist: ${source}"
+      install -m 0600 "${source}" "${PASSWORD_FILE}"
+    else
+      printf 'Kiac-%s\n' "$(openssl rand -hex 16)" > "${PASSWORD_FILE}"
+      chmod 0600 "${PASSWORD_FILE}"
+    fi
+  fi
+
+  password="$(tr -d '\r\n' < "${PASSWORD_FILE}")"
+  [[ ${#password} -ge 12 ]] || fail "Portainer admin password must contain at least 12 characters"
+  printf '%s\n' "${password}" > "${PASSWORD_FILE}"
+  chmod 0600 "${PASSWORD_FILE}"
+}
+
+write_values() {
+  cat > "${VALUES_FILE}" <<EOF
+replicaCount: 1
+
+image:
+  repository: portainer/portainer-ce
+  tag: "${PORTAINER_VERSION}"
+  pullPolicy: IfNotPresent
+
+service:
+  type: LoadBalancer
+
+tls:
+  force: true
+
+adminPassword:
+  existingSecret: portainer-admin-password
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+EOF
+  chmod 0600 "${VALUES_FILE}"
+}
+
+ensure_release() {
+  local marker="${STATE_DIR}/release.created"
+
+  kubectl --context "${CONTEXT}" -n "${NAMESPACE}" create secret generic portainer-admin-password \
+    --from-file="password=${PASSWORD_FILE}" \
+    --dry-run=client -o yaml \
+    | kubectl --context "${CONTEXT}" apply -f - >/dev/null
+
+  if helm status "${RELEASE}" --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" >/dev/null 2>&1; then
+    [[ -f "${marker}" ]] || fail "Helm release ${NAMESPACE}/${RELEASE} exists and is not owned by this lab"
+  else
+    touch "${marker}"
+  fi
+
+  step "Installing Portainer CE ${PORTAINER_VERSION}"
+  helm repo add portainer https://portainer.github.io/k8s/ --force-update >/dev/null
+  helm upgrade --install "${RELEASE}" portainer/portainer \
+    --kube-context "${CONTEXT}" \
+    --namespace "${NAMESPACE}" \
+    --version "${PORTAINER_CHART_VERSION}" \
+    --values "${VALUES_FILE}" \
+    --wait \
+    --timeout 8m
+}
+
+load_balancer_ip() {
+  local ip=""
+  local deadline=$((SECONDS + 180))
+
+  while (( SECONDS < deadline )); do
+    ip="$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" get service "${RELEASE}" \
+      -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+    if [[ -n "${ip}" ]]; then
+      printf '%s\n' "${ip}"
+      return
+    fi
+    sleep 2
+  done
+  fail "Portainer Service did not receive a LoadBalancer IP"
+}
+
+portainer_jwt() {
+  local ip="$1"
+  local password=""
+  local auth=""
+  local jwt=""
+
+  password="$(tr -d '\r\n' < "${PASSWORD_FILE}")"
+  for _ in $(seq 1 60); do
+    auth="$(jq -n --arg username admin --arg password "${password}" \
+      '{Username: $username, Password: $password}' \
+      | curl --insecure --fail --silent --show-error --max-time 10 \
+        -H 'Content-Type: application/json' --data-binary @- \
+        "https://${ip}:9443/api/auth" 2>/dev/null || true)"
+    jwt="$(jq -r '.jwt // empty' <<<"${auth}" 2>/dev/null || true)"
+    if [[ -n "${jwt}" ]]; then
+      printf '%s\n' "${jwt}"
+      return
+    fi
+    sleep 2
+  done
+  fail "Portainer login API did not return a token"
+}
+
+ensure_environment() {
+  local ip=""
+  local jwt=""
+  local endpoints=""
+  local existing_type=""
+  local created=""
+
+  ip="$(load_balancer_ip)"
+  jwt="$(portainer_jwt "${ip}")"
+  endpoints="$(curl --insecure --fail --silent --show-error --max-time 10 \
+    -H "Authorization: Bearer ${jwt}" "https://${ip}:9443/api/endpoints")"
+  existing_type="$(jq -r --arg name "${CONTEXT}" \
+    'map(select(.Name == $name)) | first | .Type // empty' <<<"${endpoints}")"
+
+  if [[ -n "${existing_type}" ]]; then
+    [[ "${existing_type}" == "5" ]] \
+      || fail "Portainer environment ${CONTEXT} exists with unexpected type ${existing_type}"
+    info "using Portainer environment ${CONTEXT}"
+    return
+  fi
+
+  step "Registering the local Kubernetes environment"
+  created="$(curl --insecure --fail --silent --show-error --max-time 30 \
+    -H "Authorization: Bearer ${jwt}" \
+    --form-string "Name=${CONTEXT}" \
+    --form-string 'EndpointCreationType=5' \
+    "https://${ip}:9443/api/endpoints")"
+  jq -e --arg name "${CONTEXT}" '.Name == $name and .Type == 5' >/dev/null <<<"${created}" \
+    || fail "Portainer did not register the local Kubernetes environment"
+}
+
+verify_lab() {
+  local ip=""
+  local status=""
+  local jwt=""
+  local endpoints=""
+  local endpoint_id=""
+  local endpoint_count="0"
+  local nodes=""
+  local node_count="0"
+
+  context_ready "${CONTEXT}" || fail "context ${CONTEXT} is not ready; run: $0 up"
+  [[ -f "${PASSWORD_FILE}" ]] || fail "admin password is absent; run: $0 up"
+
+  step "Checking the Portainer workload and storage"
+  kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/portainer --timeout=240s
+  [[ "$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" get pvc portainer -o jsonpath='{.status.phase}')" == "Bound" ]] \
+    || fail "Portainer PVC is not Bound"
+
+  ip="$(load_balancer_ip)"
+  info "LoadBalancer IP: ${ip}"
+
+  step "Checking the HTTPS status and authentication APIs"
+  for _ in $(seq 1 60); do
+    status="$(curl --insecure --fail --silent --show-error --max-time 5 \
+      "https://${ip}:9443/api/system/status" 2>/dev/null || true)"
+    if jq -e --arg version "${PORTAINER_VERSION}" '.Version == $version' \
+      >/dev/null 2>&1 <<<"${status}"; then
+      break
+    fi
+    sleep 2
+  done
+  jq -e --arg version "${PORTAINER_VERSION}" '.Version == $version' \
+    >/dev/null 2>&1 <<<"${status}" \
+    || fail "Portainer status API did not report version ${PORTAINER_VERSION}"
+
+  jwt="$(portainer_jwt "${ip}")"
+
+  for _ in $(seq 1 60); do
+    endpoints="$(curl --insecure --fail --silent --show-error --max-time 10 \
+      -H "Authorization: Bearer ${jwt}" "https://${ip}:9443/api/endpoints" 2>/dev/null || true)"
+    endpoint_count="$(jq 'if type == "array" then length else 0 end' <<<"${endpoints}" 2>/dev/null || printf '0')"
+    endpoint_id="$(jq -r --arg name "${CONTEXT}" \
+      'map(select(.Name == $name and .Type == 5 and .Status == 1)) | first | .Id // empty' \
+      <<<"${endpoints}" 2>/dev/null || true)"
+    [[ -n "${endpoint_id}" ]] && break
+    sleep 2
+  done
+  [[ -n "${endpoint_id}" ]] || fail "Portainer reports no healthy ${CONTEXT} Kubernetes environment"
+
+  nodes="$(curl --insecure --fail --silent --show-error --max-time 10 \
+    -H "Authorization: Bearer ${jwt}" \
+    "https://${ip}:9443/api/endpoints/${endpoint_id}/kubernetes/api/v1/nodes")"
+  node_count="$(jq 'if .kind == "NodeList" then (.items | length) else 0 end' <<<"${nodes}")"
+  (( node_count >= 1 )) || fail "Portainer could not read Kubernetes nodes through its API proxy"
+
+  info "Portainer API version: $(jq -r '.Version // .version // "unknown"' <<<"${status}")"
+  info "managed environments: ${endpoint_count}"
+  info "Kubernetes nodes through Portainer: ${node_count}"
+  info "UI: https://${ip}:9443"
+  info "username: admin"
+  info "password file: ${PASSWORD_FILE}"
+}
+
+up() {
+  require_tools
+  kiac doctor >/dev/null 2>&1 || fail "kiac preflight failed; run: kiac doctor"
+  prepare_state
+  ensure_cluster
+  ensure_namespace
+  ensure_password
+  write_values
+  ensure_release
+  ensure_environment
+  verify_lab
+}
+
+cleanup() {
+  require_tools
+
+  if [[ -f "${STATE_DIR}/cluster.created" ]]; then
+    step "Deleting lab cluster ${CLUSTER_NAME}"
+    kiac delete cluster --name "${CLUSTER_NAME}"
+    rm -rf "${STATE_DIR}"
+    return
+  fi
+
+  if [[ -f "${STATE_DIR}/release.created" ]]; then
+    context_ready "${CONTEXT}" || fail "cannot reach ${CONTEXT}; preserving ownership state"
+    step "Removing the owned Portainer Helm release"
+    helm uninstall "${RELEASE}" --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" --wait
+  else
+    info "leaving ${NAMESPACE}/${RELEASE} alone (no ownership marker)"
+  fi
+
+  if [[ -f "${STATE_DIR}/namespace.created" ]]; then
+    kubectl --context "${CONTEXT}" delete namespace "${NAMESPACE}" --wait=true
+  else
+    info "leaving namespace ${NAMESPACE} alone (no ownership marker)"
+  fi
+  rm -rf "${STATE_DIR}"
+}
+
+case "${1:-up}" in
+  up) up ;;
+  verify) require_tools; verify_lab ;;
+  cleanup) cleanup ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

- add an optional Portainer CE 2.39.5 LTS lab with pinned Helm chart 239.5.0
- create, verify, and clean up an isolated kiac Kubernetes 1.34 cluster with conservative ownership markers
- register the local Kubernetes environment through the Portainer API and verify Portainer can proxy a real node query
- add a dedicated Integration labs docs page and navigation across the site
- omit Okteto because its licensed installation cannot be validated in this project environment

## Verification

- `bash -n examples/portainer.sh`
- rendered the pinned Helm chart and checked the image, pull policy, PVC, LoadBalancer, admin password mount, and resource requests
- live `./examples/portainer.sh up`
- live `./examples/portainer.sh verify`: Portainer 2.39.5, one healthy Kubernetes environment, one node through the Portainer API proxy
- live `./examples/portainer.sh cleanup`: VM, kubeconfig entries, and credential state removed; pre-existing clusters untouched
- `make ci`