### PR TITLE
docs: describe Portainer as an app on kiac

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ kiac create cluster --name dev --workers 2 --observability --gateway
 
 One command later you have Grafana at port 3000 on a real LoadBalancer IP (anonymous admin, local-only, two dashboards already provisioned) and a Gateway serving HTTP on port 80, also on a LoadBalancer IP. Point an HTTPRoute at `parentRefs: [{name: kiac, namespace: kiac-gateway}]` and it routes with zero extra setup; see [`examples/gateway-api-lab.md`](examples/gateway-api-lab.md), [`examples/observability-lab.md`](examples/observability-lab.md), and [`examples/httproute.yaml`](examples/httproute.yaml). The same two flags work on kubeadm, k3s, and Cilium clusters.
 
-### Run the Portainer CE lab
+### Run Portainer CE on kiac
 
-Portainer is an optional workload, so it adds nothing to normal cluster startup or idle resource use. The lab installs Community Edition, which does not require a license key; Portainer Business Edition is the product that requires one.
+This example installs Portainer Community Edition as an optional application inside a kiac Kubernetes cluster. Portainer is not bundled with kiac and adds nothing to normal cluster startup or idle resource use. Community Edition does not require a license key; Portainer Business Edition does.
 
 ```bash
 ./examples/portainer.sh up
@@ -186,7 +186,7 @@ Portainer is an optional workload, so it adds nothing to normal cluster startup 
 ./examples/portainer.sh cleanup
 ```
 
-This is more than an install manifest. The script pins Portainer CE `2.39.5` and chart `239.5.0`, waits for its PVC and LoadBalancer address, authenticates with the generated admin credential, registers the local Kubernetes environment, and reads the cluster's nodes through Portainer's Kubernetes API proxy. The complete workflow was rerun against the released `kiac v0.5.0`; see the [website guide](https://saiyam1814.github.io/kiac/docs/portainer.html) or [`examples/portainer-lab.md`](examples/portainer-lab.md).
+The script pins Portainer CE `2.39.5` and chart `239.5.0`, waits for its PVC and LoadBalancer address, authenticates with the generated admin credential, registers the kiac cluster in Portainer, and reads the cluster's nodes through Portainer's Kubernetes API proxy. The complete workflow was rerun against the released `kiac v0.5.0`; see [Run Portainer CE on kiac](https://saiyam1814.github.io/kiac/docs/portainer.html) or [`examples/portainer-lab.md`](examples/portainer-lab.md).
 
 The [integration labs](https://saiyam1814.github.io/kiac/docs/labs.html) also cover Gateway API, observability, k8gb failover, OpenChoreo, node failure, and reboot recovery.
 

--- a/docs/docs/cilium.html
+++ b/docs/docs/cilium.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/config-file.html
+++ b/docs/docs/config-file.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/contributing.html
+++ b/docs/docs/contributing.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/dashboard.html
+++ b/docs/docs/dashboard.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/gateway-api.html
+++ b/docs/docs/gateway-api.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/getting-started.html
+++ b/docs/docs/getting-started.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
@@ -70,7 +70,7 @@
     <li><b>Clusters survive reboots.</b> <code>kiac resume cluster</code> boots the VMs back up after a host reboot and heals everything the new IPs broke. See <a href="persistence.html">Reboots &amp; resume</a>.</li>
     <li><b>Optional observability.</b> <code>--observability</code> installs Prometheus and Grafana with dashboards already provisioned. See <a href="observability.html">Observability</a>.</li>
     <li><b>Optional Gateway API.</b> <code>--gateway</code> installs the Gateway API CRDs and Traefik with a ready-to-use Gateway. See <a href="gateway-api.html">Gateway API</a>.</li>
-    <li><b>Verified integration labs.</b> Run real workflows with cleanup for Portainer CE, Gateway API, observability, k8gb, OpenChoreo, node failure, and reboot recovery. Start with the <a href="portainer.html">Portainer CE guide</a> or browse <a href="labs.html">all labs</a>.</li>
+    <li><b>Optional applications and verified examples.</b> <a href="portainer.html">Run Portainer CE on kiac</a>, or follow repeatable workflows for Gateway API, observability, k8gb, OpenChoreo, node failure, and reboot recovery. Browse <a href="labs.html">all integration labs</a>.</li>
     <li><b>Node chaos.</b> <code>kiac stop node</code> / <code>kiac start node</code> stop and restart a real node VM. See <a href="node-chaos.html">Node chaos</a>.</li>
     <li><b>A local dashboard.</b> <code>kiac ui</code> opens a web console with cluster cards, live resource bars, a kubectl console drawer, and a create form. See <a href="dashboard.html">Dashboard</a>.</li>
   </ul>

--- a/docs/docs/k3s.html
+++ b/docs/docs/k3s.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/labs.html
+++ b/docs/docs/labs.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a class="on" href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
@@ -56,19 +56,19 @@
   <h1>Integration labs</h1>
   <p class="lede">Repeatable workflows that exercise real traffic, storage, APIs, and failure paths on kiac clusters. Each lab includes verification and cleanup instead of stopping at installation.</p>
 
-  <h2 id="portainer">Portainer CE</h2>
+  <h2 id="portainer">Run Portainer CE on kiac</h2>
   <div class="product-head">
     <img src="../assets/portainer-mark.svg" alt="">
     <div><strong>Portainer Community Edition</strong><span>Optional Kubernetes management UI; no key required</span></div>
     <a class="product-link" href="portainer.html">Open the full guide</a>
   </div>
-  <p>This lab was freshly rerun end to end with the released <code>kiac v0.5.0</code>. It pins Portainer CE <code>2.39.5</code> and chart <code>239.5.0</code>, binds persistent storage, receives a real LoadBalancer IP, authenticates through the Portainer API, registers the local environment, and reads Kubernetes nodes through Portainer's API proxy.</p>
+  <p>Portainer runs as an optional application inside the kiac Kubernetes cluster; it is not built into kiac. The installation example was freshly rerun end to end with <code>kiac v0.5.0</code>. It pins Portainer CE <code>2.39.5</code> and chart <code>239.5.0</code>, binds persistent storage, receives a real LoadBalancer IP, authenticates through the Portainer API, registers the kiac cluster, and reads Kubernetes nodes through Portainer's API proxy.</p>
   <div class="note"><b>No license key is needed</b>
   This installs Portainer Community Edition. Portainer Business Edition is a separate product and does require a license key.</div>
   <pre><code>./examples/portainer.sh up
 ./examples/portainer.sh verify
 ./examples/portainer.sh cleanup</code></pre>
-  <div class="lab-actions"><a href="portainer.html">Step-by-step Portainer guide</a><a href="https://github.com/saiyam1814/kiac/blob/main/examples/portainer.sh">Lab script</a></div>
+  <div class="lab-actions"><a href="portainer.html">Run Portainer on kiac</a><a href="https://github.com/saiyam1814/kiac/blob/main/examples/portainer.sh">Installation script</a></div>
   <p>Portainer manages the Kubernetes cluster; it does not provide Docker Engine or Docker Compose compatibility for the macOS host.</p>
 
   <h2 id="addons">Gateway API and observability</h2>

--- a/docs/docs/networking.html
+++ b/docs/docs/networking.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/node-chaos.html
+++ b/docs/docs/node-chaos.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a class="on" href="node-chaos.html">Node chaos</a>

--- a/docs/docs/observability.html
+++ b/docs/docs/observability.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/persistence.html
+++ b/docs/docs/persistence.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/portainer.html
+++ b/docs/docs/portainer.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Portainer CE lab - kiac docs</title>
+<title>Run Portainer CE on kiac - kiac docs</title>
 <meta name="description" content="Install and verify Portainer Community Edition without a license key on a kiac Kubernetes cluster, including storage, LoadBalancer access, API authentication, and cleanup.">
 <link rel="icon" type="image/svg+xml" href="../assets/logo-mark.svg">
 <link rel="stylesheet" href="docs.css">
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a class="on" href="portainer.html">Portainer CE</a>
+    <a class="on" href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>
@@ -52,9 +52,9 @@
   </div>
 </aside>
 <main>
-  <div class="kicker">Integration lab</div>
-  <h1>Portainer CE on kiac</h1>
-  <p class="lede">A repeatable, disposable Portainer environment that proves the whole path from Kubernetes storage and LoadBalancer networking to authenticated Portainer API access.</p>
+  <div class="kicker">Optional application</div>
+  <h1>Run Portainer CE on kiac</h1>
+  <p class="lede">Install Portainer Community Edition as an application inside a kiac Kubernetes cluster, expose its UI, and verify that it can manage the cluster.</p>
 
   <div class="product-head">
     <img src="../assets/portainer-mark.svg" alt="">
@@ -63,11 +63,11 @@
   </div>
 
   <div class="note"><b>No Portainer license key is required</b>
-  The lab installs the open-source Community Edition image, <code>portainer/portainer-ce</code>. Portainer Business Edition is the edition that asks for a license key.</div>
+  This example installs the open-source Community Edition image, <code>portainer/portainer-ce</code>. Portainer Business Edition is the edition that asks for a license key.</div>
 
   <div class="verification-record"><b>Fresh validation:</b> both <code>up</code> and a separate <code>verify</code> run passed against the released <code>kiac v0.5.0</code>. Cleanup then removed the cluster, kubeconfig context, and generated credential state.</div>
 
-  <h2 id="proves">What the lab proves</h2>
+  <h2 id="proves">What the example verifies</h2>
   <div class="proof-grid">
     <div class="proof-item"><b>Reproducible versions</b><span>Portainer CE 2.39.5, chart 239.5.0, Kubernetes 1.34</span></div>
     <div class="proof-item"><b>Persistent storage</b><span>The 5 GiB local-path PVC reaches Bound</span></div>
@@ -76,7 +76,7 @@
     <div class="proof-item"><b>Real authentication</b><span>The admin credential obtains a Portainer JWT</span></div>
     <div class="proof-item"><b>Kubernetes management</b><span>A healthy Type 5 environment is registered</span></div>
     <div class="proof-item"><b>API proxy path</b><span>Portainer returns a NodeList from Kubernetes</span></div>
-    <div class="proof-item"><b>Owned cleanup</b><span>Only lab-created resources and state are deleted</span></div>
+    <div class="proof-item"><b>Owned cleanup</b><span>Only resources and state created by the script are deleted</span></div>
   </div>
 
   <pre><code>macOS browser or API
@@ -97,7 +97,7 @@ kiac doctor</code></pre>
 
   <h2 id="start">Create and install</h2>
   <pre><code>./examples/portainer.sh up</code></pre>
-  <p>The default run creates an isolated, single-node cluster named <code>portainer-lab</code>. It then creates the namespace and password, installs the pinned chart, waits for the Deployment and PVC, discovers the LoadBalancer IP, signs into the API, and idempotently registers the Kubernetes environment.</p>
+  <p>By default, the script creates an isolated, single-node kiac cluster named <code>portainer-lab</code>. It then creates the namespace and password, installs the pinned chart, waits for the Deployment and PVC, discovers the LoadBalancer IP, signs into the API, and idempotently registers the cluster in Portainer.</p>
   <p>A successful run ends with output like this:</p>
   <pre><code><span class="o">Portainer API version: 2.39.5</span>
 <span class="o">managed environments: 1</span>
@@ -106,7 +106,7 @@ UI: https://192.168.64.x:9443
 username: admin
 password file: ~/.kiac/labs/portainer/portainer-lab/admin-password</code></pre>
   <div class="warn"><b>Local certificate</b>
-  Portainer generates a self-signed certificate for this local lab, so the browser warns before opening the HTTPS UI. Keep the LoadBalancer address on a trusted local network.</div>
+  Portainer generates a self-signed certificate for this local installation, so the browser warns before opening the HTTPS UI. Keep the LoadBalancer address on a trusted local network.</div>
 
   <h2 id="verify">Verify the real user path</h2>
   <pre><code>./examples/portainer.sh verify</code></pre>
@@ -119,24 +119,24 @@ password file: ~/.kiac/labs/portainer/portainer-lab/admin-password</code></pre>
   <pre><code>KIAC_PORTAINER_CLUSTER=dev \
 KIAC_PORTAINER_USE_EXISTING=true \
 ./examples/portainer.sh up</code></pre>
-  <p>The script refuses to adopt a pre-existing <code>portainer</code> namespace or Helm release. Ownership markers ensure cleanup removes only what this lab created and never deletes an existing cluster.</p>
+  <p>The script refuses to adopt a pre-existing <code>portainer</code> namespace or Helm release. Ownership markers ensure cleanup removes only what the script created and never deletes an existing cluster.</p>
   <p>To choose the password without placing it in shell history:</p>
   <pre><code>PORTAINER_ADMIN_PASSWORD_FILE="$HOME/.config/portainer-lab-password" \
 ./examples/portainer.sh up</code></pre>
 
   <h2 id="cleanup">Clean up</h2>
   <pre><code>./examples/portainer.sh cleanup</code></pre>
-  <p>For the default lab, this deletes the owned kiac cluster and its credential state. When using an existing cluster, it removes only the owned Helm release, namespace, and local password copy.</p>
+  <p>For the default installation, this deletes the kiac cluster created by the script and its credential state. When using an existing cluster, it removes only the owned Helm release, namespace, and local password copy.</p>
 
   <h2 id="boundaries">Scope and security</h2>
   <ul>
     <li>Portainer receives cluster-admin privileges because it manages this local Kubernetes environment.</li>
     <li>The generated credential is local state; do not commit or share it.</li>
     <li>Use a trusted certificate and external authentication for a shared deployment.</li>
-    <li>This lab manages Kubernetes. It does not turn apple/container into Docker Engine or add Docker Compose compatibility to macOS.</li>
+    <li>This Portainer installation manages Kubernetes. It does not turn apple/container into Docker Engine or add Docker Compose compatibility to macOS.</li>
   </ul>
 
-  <div class="lab-actions"><a href="https://github.com/saiyam1814/kiac/blob/main/examples/portainer.sh">Read the script</a><a href="https://github.com/saiyam1814/kiac/blob/main/examples/portainer-lab.md">Markdown lab</a><a href="https://docs.portainer.io/start/install-ce/server/kubernetes">Portainer Kubernetes docs</a></div>
+  <div class="lab-actions"><a href="https://github.com/saiyam1814/kiac/blob/main/examples/portainer.sh">Read the script</a><a href="https://github.com/saiyam1814/kiac/blob/main/examples/portainer-lab.md">Markdown guide</a><a href="https://docs.portainer.io/start/install-ce/server/kubernetes">Portainer Kubernetes docs</a></div>
 
   <div class="pn">
     <a href="labs.html"><span>Previous</span>Integration labs</a>

--- a/docs/docs/storage-and-metrics.html
+++ b/docs/docs/storage-and-metrics.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/docs/troubleshooting.html
+++ b/docs/docs/troubleshooting.html
@@ -39,7 +39,7 @@
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
-    <a href="portainer.html">Portainer CE</a>
+    <a href="portainer.html">Portainer on kiac</a>
   </div>
   <div class="group"><div class="glabel">Day two</div>
     <a href="node-chaos.html">Node chaos</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -344,9 +344,9 @@
 </section>
 
 <section id="labs">
-  <div class="kicker">Verified labs</div>
+  <div class="kicker">Optional applications</div>
   <h2>Run the integration, then prove it works.</h2>
-  <p class="lede">Each lab owns its setup, checks the user-facing path, and cleans up after itself. Integrations stay outside the kiac binary, so normal clusters pay no startup or idle-resource cost.</p>
+  <p class="lede">Run applications on kiac with repeatable setup, real user-facing checks, and cleanup. These examples stay outside the kiac binary, so normal clusters pay no startup or idle-resource cost.</p>
   <div class="lab-showcase">
     <div class="lab-copy">
       <div class="portainer-lockup">
@@ -354,11 +354,11 @@
         <div><strong>Portainer Community Edition</strong><span>Optional Kubernetes management UI</span></div>
       </div>
       <p class="license">No license key required.</p>
-      <p>The lab pins Portainer CE 2.39.5, creates persistent storage and a real LoadBalancer endpoint, protects the generated admin password, and registers the local Kubernetes environment.</p>
+      <p>This example installs Portainer CE 2.39.5 inside a kiac cluster, creates persistent storage and a real LoadBalancer endpoint, protects the generated admin password, and registers the kiac cluster in Portainer.</p>
       <pre class="lab-command">./examples/portainer.sh up
 ./examples/portainer.sh verify
 ./examples/portainer.sh cleanup</pre>
-      <div class="lab-links"><a href="docs/portainer.html">Portainer guide</a><a href="docs/labs.html">All integration labs</a></div>
+      <div class="lab-links"><a href="docs/portainer.html">Run Portainer on kiac</a><a href="docs/labs.html">All integration labs</a></div>
     </div>
     <div class="lab-proof">
       <div><b>Authenticated, not assumed</b><span>The verifier obtains a JWT from the live Portainer API.</span></div>

--- a/examples/portainer-lab.md
+++ b/examples/portainer-lab.md
@@ -1,10 +1,10 @@
-# Portainer CE lab
+# Run Portainer CE on kiac
 
-[Portainer](https://www.portainer.io/) is a web interface for managing containers and Kubernetes environments. This lab installs Portainer Community Edition inside a real kiac cluster and exposes it through kiac's built-in LoadBalancer.
+[Portainer](https://www.portainer.io/) is a web interface for managing containers and Kubernetes environments. This example installs Portainer Community Edition as an application inside a kiac cluster and exposes it through kiac's built-in LoadBalancer.
 
-Portainer is an optional workload, not a kiac addon. The lab keeps Portainer's cluster-admin access, persistent data, credentials, and lifecycle explicit instead of adding them to every cluster.
+Portainer is optional: it is not bundled with kiac and is not installed during normal cluster creation. The example keeps Portainer's cluster-admin access, persistent data, credentials, and lifecycle explicit.
 
-## What the lab builds
+## What the example installs
 
 ```mermaid
 flowchart LR
@@ -30,9 +30,9 @@ brew install helm jq
 kiac doctor
 ```
 
-Portainer CE does not require a license key. This lab never installs or enables Business Edition, which has a separate licensing flow. See Portainer's official [Community Edition install guide](https://docs.portainer.io/start/install-ce/server/kubernetes) and [Business Edition install guide](https://docs.portainer.io/start/install/server/kubernetes) for the distinction. The official images and chart support arm64.
+Portainer CE does not require a license key. This example never installs or enables Business Edition, which has a separate licensing flow. See Portainer's official [Community Edition install guide](https://docs.portainer.io/start/install-ce/server/kubernetes) and [Business Edition install guide](https://docs.portainer.io/start/install/server/kubernetes) for the distinction. The official images and chart support arm64.
 
-## Start the lab
+## Install Portainer on kiac
 
 From a kiac checkout:
 
@@ -40,7 +40,7 @@ From a kiac checkout:
 ./examples/portainer.sh up
 ```
 
-The first run creates `portainer-lab`, installs Portainer, waits for its Deployment and PVC, obtains the LoadBalancer IP, authenticates through the Portainer API, and registers the in-cluster Kubernetes environment. The current Portainer chart does not perform that final onboarding step automatically, so the lab makes it explicit and idempotent.
+The first run creates a kiac cluster named `portainer-lab`, installs Portainer, waits for its Deployment and PVC, obtains the LoadBalancer IP, authenticates through the Portainer API, and registers the kiac cluster in Portainer. The current Portainer chart does not perform that final onboarding step automatically, so the script makes it explicit and idempotent.
 
 At the end it prints output similar to:
 
@@ -91,7 +91,7 @@ KIAC_PORTAINER_USE_EXISTING=true \
 ./examples/portainer.sh up
 ```
 
-The script refuses to adopt an existing `portainer` namespace or Helm release. Its ownership markers let cleanup remove only resources created by this lab, never the existing cluster.
+The script refuses to adopt an existing `portainer` namespace or Helm release. Its ownership markers let cleanup remove only resources created by the script, never the existing cluster.
 
 To provide your own password without putting it in shell history:
 
@@ -108,12 +108,12 @@ The password must contain at least 12 characters.
 ./examples/portainer.sh cleanup
 ```
 
-For the default lab, this deletes the owned kiac cluster and its state directory. On an existing cluster, it removes only the owned Helm release and namespace, then deletes the local password copy.
+For the default installation, this deletes the kiac cluster created by the script and its state directory. On an existing cluster, it removes only the owned Helm release and namespace, then deletes the local password copy.
 
 ## Scope and security
 
-Portainer receives cluster-admin privileges because it manages the local Kubernetes environment. Use this lab only on a local development cluster, do not expose its LoadBalancer address beyond trusted networks, and use a trusted certificate plus external authentication for a shared deployment.
+Portainer receives cluster-admin privileges because it manages the local Kubernetes environment. Use this example only on a local development cluster, do not expose its LoadBalancer address beyond trusted networks, and use a trusted certificate plus external authentication for a shared deployment.
 
-This lab demonstrates Kubernetes management. It does not turn apple/container into Docker Engine, add Docker Compose compatibility, or make Portainer manage the macOS host runtime.
+This example demonstrates Portainer managing Kubernetes on kiac. It does not turn apple/container into Docker Engine, add Docker Compose compatibility, or make Portainer manage the macOS host runtime.
 
 See Portainer's [Kubernetes installation guide](https://docs.portainer.io/start/install-ce/server/kubernetes/baremetal) and [validated configurations](https://docs.portainer.io/start/requirements-and-prerequisites) for upstream details.

--- a/examples/portainer.sh
+++ b/examples/portainer.sh
@@ -25,7 +25,7 @@ Usage: $0 [up|verify|cleanup]
 
   up        Create a small Kubernetes 1.34 cluster and install Portainer CE
   verify    Check the Deployment, PVC, LoadBalancer, status API, and login API
-  cleanup   Delete only the Portainer resources and cluster owned by this lab
+  cleanup   Delete only Portainer resources and clusters created by this script
 
 Environment:
   KIAC_PORTAINER_CLUSTER=<name>         cluster name (default: portainer-lab)
@@ -78,14 +78,14 @@ ensure_cluster() {
       info "using ready cluster ${CLUSTER_NAME}"
       return
     fi
-    fail "context ${CONTEXT} is live but is not owned by this lab; set KIAC_PORTAINER_USE_EXISTING=true to use it"
+    fail "context ${CONTEXT} is live but was not created by this script; set KIAC_PORTAINER_USE_EXISTING=true to use it"
   fi
 
   use_existing && fail "KIAC_PORTAINER_USE_EXISTING=true, but context ${CONTEXT} is not ready"
 
   if container_exists "${node}"; then
-    [[ -f "${marker}" ]] || fail "cluster ${CLUSTER_NAME} exists and is not owned by this lab"
-    step "Resuming lab cluster ${CLUSTER_NAME}"
+    [[ -f "${marker}" ]] || fail "cluster ${CLUSTER_NAME} exists and was not created by this script"
+    step "Resuming Portainer cluster ${CLUSTER_NAME}"
     kiac resume cluster --name "${CLUSTER_NAME}"
     context_ready "${CONTEXT}" || fail "context ${CONTEXT} is not ready after resume"
     return
@@ -111,7 +111,7 @@ ensure_namespace() {
   local marker="${STATE_DIR}/namespace.created"
 
   if kubectl --context "${CONTEXT}" get namespace "${NAMESPACE}" >/dev/null 2>&1; then
-    [[ -f "${marker}" ]] || fail "namespace ${NAMESPACE} already exists and is not owned by this lab"
+    [[ -f "${marker}" ]] || fail "namespace ${NAMESPACE} already exists and was not created by this script"
     return
   fi
 
@@ -178,7 +178,7 @@ ensure_release() {
     | kubectl --context "${CONTEXT}" apply -f - >/dev/null
 
   if helm status "${RELEASE}" --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" >/dev/null 2>&1; then
-    [[ -f "${marker}" ]] || fail "Helm release ${NAMESPACE}/${RELEASE} exists and is not owned by this lab"
+    [[ -f "${marker}" ]] || fail "Helm release ${NAMESPACE}/${RELEASE} exists and was not created by this script"
   else
     touch "${marker}"
   fi
@@ -344,7 +344,7 @@ cleanup() {
   require_tools
 
   if [[ -f "${STATE_DIR}/cluster.created" ]]; then
-    step "Deleting lab cluster ${CLUSTER_NAME}"
+    step "Deleting Portainer cluster ${CLUSTER_NAME}"
     kiac delete cluster --name "${CLUSTER_NAME}"
     rm -rf "${STATE_DIR}"
     return


### PR DESCRIPTION
## Summary

- rename the user-facing guide to **Run Portainer CE on kiac**
- state directly that Portainer runs as an optional application inside a kiac Kubernetes cluster
- clarify that Portainer is not bundled with kiac or installed during normal cluster creation
- replace ambiguous "lab" language with "example," "installation," or "script"
- label the docs navigation **Portainer on kiac**
- preserve the existing portainer-lab cluster name, file name, and state paths for compatibility

## Validation

- make ci
- bash -n examples/portainer.sh
- ./examples/portainer.sh --help
- html-validate docs/docs/portainer.html
- all local HTML href and src targets resolve
- git diff --check
