### PR TITLE
fix: disable sender-side TSO/GSO on node NICs

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -78,6 +78,17 @@ const ipv6BootPrep = `KIAC_IF="$(ip -4 route show default 2>/dev/null | awk '{pr
 	`[ -n "$KIAC_IF" ] && sysctl -w "net.ipv6.conf.$KIAC_IF.accept_ra=2" >/dev/null 2>&1; ` +
 	`sysctl -w net.ipv6.conf.all.forwarding=1 >/dev/null 2>&1 || true; `
 
+// vmnet mishandles TSO/GSO-deferred TCP streams between sibling VMs once
+// the receiving node forwards them across a veth into a pod - the same
+// pathology as issue #8, but VM-to-VM, where the edge proxy cannot sit.
+// A pod pulling a large body from the API server (kubectl's ~6.5MB
+// OpenAPI download inside a job, for example) crawls at KB/s and times
+// out. Disabling segmentation offload on the sending side keeps those
+// transfers at line rate. Offloads are runtime state, so this runs on
+// every boot and resume. Best-effort: a node without ethtool still
+// works, just slower.
+const senderOffloadFix = "command -v ethtool >/dev/null 2>&1 && ethtool -K eth0 tso off gso off || true"
+
 // WantsIPv6 reports whether the family carries IPv6 traffic at all.
 func (f IPFamily) WantsIPv6() bool { return f == DualStack || f == IPv6 }
 
@@ -232,6 +243,9 @@ func (m *Manager) Create(cfg Config) error {
 				return err
 			}
 			if _, err := m.rt.Exec(n, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+				return err
+			}
+			if _, err := m.rt.Exec(n, "sh", "-c", senderOffloadFix); err != nil {
 				return err
 			}
 			if cfg.family().WantsIPv6() {

--- a/pkg/cluster/k3s.go
+++ b/pkg/cluster/k3s.go
@@ -85,7 +85,8 @@ func k3sAgentArgs(nodeName string) []string {
 // backend (CONFIG_IP_NF_IPTABLES_LEGACY=y) is fully supported. Both
 // variants ship in the image under /bin/aux.
 func k3sBoot(cfg Config, k3sArgs []string) (entrypoint string, args []string) {
-	cmd := "for t in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do ln -sf xtables-legacy-multi /bin/aux/$t; done; " +
+	cmd := senderOffloadFix + "; " +
+		"for t in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do ln -sf xtables-legacy-multi /bin/aux/$t; done; " +
 		"if [ -x " + kiacLBScriptPath + " ]; then " +
 		"mkdir -p /var/log /var/run; " +
 		"if ! kill -0 \"$(cat " + kiacLBK3sSupervisorPID + " 2>/dev/null)\" 2>/dev/null; then " +

--- a/pkg/cluster/persist.go
+++ b/pkg/cluster/persist.go
@@ -74,8 +74,12 @@ func (m *Manager) Resume(name string, waitTimeout time.Duration) error {
 			if err := m.bootAndWait(n, waitTimeout); err != nil {
 				return err
 			}
-			// ip_forward is runtime state; the reboot reset it.
+			// ip_forward and NIC offloads are runtime state; the reboot
+			// reset both.
 			if _, err := m.rt.Exec(n, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+				return err
+			}
+			if _, err := m.rt.Exec(n, "sh", "-c", senderOffloadFix); err != nil {
 				return err
 			}
 			// A dual-stack node's kubelet --node-ip pins the OLD v4 and v6


### PR DESCRIPTION
## Problem

vmnet mishandles TSO/GSO-deferred TCP streams between sibling VMs once the receiving node forwards them across a veth into a pod - the same pathology as #8, but VM-to-VM, where the edge proxy cannot sit. Pods reading large bodies from the API server crawl at ~7KB/s. OpenChoreo 1.2.2's authz-bootstrap job (kubectl apply downloads a ~6.5MB OpenAPI schema against kubectl's 32s discovery timeout) fails outright with DeadlineExceeded, breaking the upstream kiac installer on 1.2.x.

## Fix

Disable tso/gso on the sending side of every node NIC. Measured on the failing transfer: 7KB/s -> 120MB/s. Offloads are runtime state, so the fix runs on every kubeadm boot, on resume, and in the k3s boot command (which also covers k3s resume, since it re-runs the entrypoint). Best-effort when ethtool is absent - the node image ships ethtool 6.14.2.

## Validation

- Reproduced on a live cluster: pod->apiserver /openapi/v2 (6.5MB) at 7.5KB/s stock; 120MB/s after sender-side tso/gso off. Receiver-side knobs (eth0 gro/gso/tso, veth offloads, checksums) did not help - confirming the sender-side deferral as the cause.
- OpenChoreo 1.2.2 then installs end to end on kiac (authz-bootstrap passes), sample component deploys, endpoint reachable through kiac-lb.
- `make ci` green under the pinned Go 1.25.12 toolchain.

The installer fix drafted with AI assistance (Claude) and validated end to end on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)