### PR TITLE
fix: pass --enable-kernel-install to container system start to avoid hanging on kernel prompt

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -50,39 +50,35 @@ var doctorCmd = &cobra.Command{
 
 		if cliOK {
 			running := rt.SystemRunning()
-			switch {
-			case !running && doctorFix:
-				// Before/after both go through ui.Check so a fix is never silent.
-				ui.Check(false, "container system service", "stopped - fixing: container system start")
-				if err := rt.SystemStart(); err != nil {
-					failures++
-					ui.Check(false, "container system service", "start failed: "+err.Error())
-				} else if rt.SystemRunning() {
-					ui.Check(true, "container system service", "running (started by --fix)")
+			if doctorFix {
+				if !running {
+					ui.Check(false, "container system service", "stopped - fixing: container system start")
+				}
+				startErr := rt.SystemStart(true)
+				nowRunning := rt.SystemRunning()
+				if nowRunning {
+					detail := "running"
+					if !running {
+						detail = "running (started by --fix)"
+					}
+					ui.Check(true, "container system service", detail)
 				} else {
 					failures++
 					ui.Check(false, "container system service", "still not running after start; inspect with: container system status")
 				}
-			case running:
-				ui.Check(true, "container system service", "running")
-			default:
-				ui.Check(false, "container system service", "stopped - kiac will start it automatically on create, or run: kiac doctor --fix")
-			}
-
-			// A running service doesn't mean a kernel is configured.
-			// If an earlier interactive prompt never got answered, the
-			// service comes up with no kernel and everything here still
-			// passes (#35). container system start always rechecks the
-			// kernel and installs one if missing, so run it again.
-			if doctorFix {
-				if err := rt.SystemStart(); err != nil {
+				if startErr != nil {
 					failures++
-					ui.Check(false, "default kernel", "install failed: "+err.Error())
+					ui.Check(false, "default kernel", "install failed: "+startErr.Error())
 				} else {
 					ui.Check(true, "default kernel", "configured (verified/installed by --fix)")
 				}
-			} else if running {
-				ui.Hintf("default kernel is not verified without --fix; run: kiac doctor --fix")
+			} else {
+				if running {
+					ui.Check(true, "container system service", "running")
+					ui.Hintf("default kernel is not verified without --fix; run: kiac doctor --fix")
+				} else {
+					ui.Check(false, "container system service", "stopped - kiac will start it automatically on create, or run: kiac doctor --fix")
+				}
 			}
 		}
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -68,6 +68,22 @@ var doctorCmd = &cobra.Command{
 			default:
 				ui.Check(false, "container system service", "stopped - kiac will start it automatically on create, or run: kiac doctor --fix")
 			}
+
+			// A running service doesn't mean a kernel is configured.
+			// If an earlier interactive prompt never got answered, the
+			// service comes up with no kernel and everything here still
+			// passes (#35). container system start always rechecks the
+			// kernel and installs one if missing, so run it again.
+			if doctorFix {
+				if err := rt.SystemStart(); err != nil {
+					failures++
+					ui.Check(false, "default kernel", "install failed: "+err.Error())
+				} else {
+					ui.Check(true, "default kernel", "configured (verified/installed by --fix)")
+				}
+			} else if running {
+				ui.Hintf("default kernel is not verified without --fix; run: kiac doctor --fix")
+			}
 		}
 
 		_, kubectlErr := exec.LookPath("kubectl")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -204,7 +204,7 @@ func (m *Manager) Create(cfg Config) error {
 	}
 
 	if err := ui.Step("Preflight checks", func() error {
-		if err := m.preflight(); err != nil {
+		if err := m.preflight(cfg.Kernel == ""); err != nil {
 			return err
 		}
 		return m.preflightIPv6Network(cfg)
@@ -600,7 +600,7 @@ func (m *Manager) installCilium(cp string, cfg Config) error {
 }
 
 // preflight validates the host before any VM is booted.
-func (m *Manager) preflight() error {
+func (m *Manager) preflight(installDefaultKernel bool) error {
 	if !m.rt.Available() {
 		return fmt.Errorf("apple/container CLI not found on PATH; install it from https://github.com/apple/container/releases")
 	}
@@ -611,13 +611,14 @@ func (m *Manager) preflight() error {
 	if err := runtime.ValidateNodeRuntimeVersion(version); err != nil {
 		return err
 	}
-	// SystemStart is idempotent: it starts the apiserver if needed and
-	// installs the default kernel if one isn't configured. Call it every
-	// time, not just when the service is stopped, so a service left
-	// running with no kernel doesn't slip past preflight and fail later
-	// during node VM boot instead (#35).
-	if err := m.rt.SystemStart(); err != nil {
-		return fmt.Errorf("container system service could not be started, or its default kernel could not be installed: %w", err)
+	// Always choose a non-interactive kernel mode. Default-kernel clusters
+	// install the recommendation if needed; custom-kernel clusters avoid
+	// an unrelated download and only start the service.
+	if err := m.rt.SystemStart(installDefaultKernel); err != nil {
+		if installDefaultKernel {
+			return fmt.Errorf("container system service could not be started, or its default kernel could not be installed: %w", err)
+		}
+		return fmt.Errorf("container system service could not be started: %w", err)
 	}
 	return nil
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -611,10 +611,13 @@ func (m *Manager) preflight() error {
 	if err := runtime.ValidateNodeRuntimeVersion(version); err != nil {
 		return err
 	}
-	if !m.rt.SystemRunning() {
-		if err := m.rt.SystemStart(); err != nil {
-			return fmt.Errorf("container system service is not running and could not be started: %w", err)
-		}
+	// SystemStart is idempotent: it starts the apiserver if needed and
+	// installs the default kernel if one isn't configured. Call it every
+	// time, not just when the service is stopped, so a service left
+	// running with no kernel doesn't slip past preflight and fail later
+	// during node VM boot instead (#35).
+	if err := m.rt.SystemStart(); err != nil {
+		return fmt.Errorf("container system service could not be started, or its default kernel could not be installed: %w", err)
 	}
 	return nil
 }

--- a/pkg/cluster/k3s.go
+++ b/pkg/cluster/k3s.go
@@ -250,7 +250,7 @@ func (m *Manager) CreateK3s(cfg Config) error {
 	}
 
 	if err := ui.Step("Preflight checks", func() error {
-		if err := m.preflight(); err != nil {
+		if err := m.preflight(cfg.Kernel == ""); err != nil {
 			return err
 		}
 		return m.preflightIPv6Network(cfg)

--- a/pkg/cluster/k3s_resume.go
+++ b/pkg/cluster/k3s_resume.go
@@ -60,7 +60,7 @@ func (m *Manager) resumeK3s(name string, infos []runtime.Info, waitTimeout time.
 	if err != nil {
 		return err
 	}
-	if err := ui.Step("Preflight checks", func() error { return m.preflight() }); err != nil {
+	if err := ui.Step("Preflight checks", func() error { return m.preflight(false) }); err != nil {
 		return err
 	}
 

--- a/pkg/cluster/persist.go
+++ b/pkg/cluster/persist.go
@@ -47,7 +47,7 @@ func (m *Manager) Resume(name string, waitTimeout time.Duration) error {
 		return err
 	}
 
-	if err := ui.Step("Preflight checks", func() error { return m.preflight() }); err != nil {
+	if err := ui.Step("Preflight checks", func() error { return m.preflight(false) }); err != nil {
 		return err
 	}
 

--- a/pkg/runtime/container.go
+++ b/pkg/runtime/container.go
@@ -102,9 +102,16 @@ func (c *Client) SystemStatus(timeout time.Duration) (string, error) {
 	return c.runContext(ctx, "system", "status")
 }
 
-// SystemStart starts the container API server.
+// SystemStart starts the container API server and installs a default
+// kernel if none is configured. Plain `container system start` prompts
+// for that ("Install the recommended default kernel? [Y/n]"), which
+// just hangs with no terminal attached (issue #35). --enable-kernel-install
+// makes it non-interactive.
+//
+// Safe to call even when the service is already running: it checks for
+// a kernel every time and returns fast if one's already installed.
 func (c *Client) SystemStart() error {
-	_, err := c.run("system", "start")
+	_, err := c.run("system", "start", "--enable-kernel-install")
 	return err
 }
 

--- a/pkg/runtime/container.go
+++ b/pkg/runtime/container.go
@@ -102,16 +102,15 @@ func (c *Client) SystemStatus(timeout time.Duration) (string, error) {
 	return c.runContext(ctx, "system", "status")
 }
 
-// SystemStart starts the container API server and installs a default
-// kernel if none is configured. Plain `container system start` prompts
-// for that ("Install the recommended default kernel? [Y/n]"), which
-// just hangs with no terminal attached (issue #35). --enable-kernel-install
-// makes it non-interactive.
-//
-// Safe to call even when the service is already running: it checks for
-// a kernel every time and returns fast if one's already installed.
-func (c *Client) SystemStart() error {
-	_, err := c.run("system", "start", "--enable-kernel-install")
+// SystemStart starts the container API server without prompting. When
+// installDefaultKernel is true it also installs the recommended kernel
+// if none is configured; false preserves custom-kernel-only setups.
+func (c *Client) SystemStart(installDefaultKernel bool) error {
+	kernelFlag := "--disable-kernel-install"
+	if installDefaultKernel {
+		kernelFlag = "--enable-kernel-install"
+	}
+	_, err := c.run("system", "start", kernelFlag)
 	return err
 }
 

--- a/pkg/runtime/container_test.go
+++ b/pkg/runtime/container_test.go
@@ -128,6 +128,23 @@ func TestRunDetachedOmitsDNSWhenUnset(t *testing.T) {
 	}
 }
 
+// container system start hangs on a Y/n prompt if no kernel is
+// configured (#35), so SystemStart must pass --enable-kernel-install.
+func TestSystemStartEnablesKernelInstall(t *testing.T) {
+	argsFile := filepath.Join(t.TempDir(), "args")
+	client := fakeContainerClient(t, "", argsFile)
+
+	if err := client.SystemStart(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readArgs(t, argsFile)
+	want := []string{"system", "start", "--enable-kernel-install"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("system start args = %q, want %q", got, want)
+	}
+}
+
 func TestValidateNodeRuntimeVersion(t *testing.T) {
 	for _, version := range []string{"0.8.0", "1.0.0", "1.1.0", "1.2.1", "1.2.2", "2.0.0"} {
 		if err := ValidateNodeRuntimeVersion(version); err != nil {

--- a/pkg/runtime/container_test.go
+++ b/pkg/runtime/container_test.go
@@ -128,20 +128,29 @@ func TestRunDetachedOmitsDNSWhenUnset(t *testing.T) {
 	}
 }
 
-// container system start hangs on a Y/n prompt if no kernel is
-// configured (#35), so SystemStart must pass --enable-kernel-install.
-func TestSystemStartEnablesKernelInstall(t *testing.T) {
-	argsFile := filepath.Join(t.TempDir(), "args")
-	client := fakeContainerClient(t, "", argsFile)
+func TestSystemStartSelectsKernelInstallMode(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		installKernel bool
+		wantFlag      string
+	}{
+		{name: "default kernel required", installKernel: true, wantFlag: "--enable-kernel-install"},
+		{name: "custom kernel supplied", installKernel: false, wantFlag: "--disable-kernel-install"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			argsFile := filepath.Join(t.TempDir(), "args")
+			client := fakeContainerClient(t, "", argsFile)
 
-	if err := client.SystemStart(); err != nil {
-		t.Fatal(err)
-	}
+			if err := client.SystemStart(tc.installKernel); err != nil {
+				t.Fatal(err)
+			}
 
-	got := readArgs(t, argsFile)
-	want := []string{"system", "start", "--enable-kernel-install"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("system start args = %q, want %q", got, want)
+			got := readArgs(t, argsFile)
+			want := []string{"system", "start", tc.wantFlag}
+			if !slices.Equal(got, want) {
+				t.Fatalf("system start args = %q, want %q", got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #35

`container system start` prompts for kernel install (Y/n) when no kernel's configured, and that hangs with no terminal attached during `kiac create cluster`. preflight/doctor --fix don't catch it either, so it just fails later with "**kernel not configured for architecture arm64**" during node boot.

- `SystemStart()` now passes `--enable-kernel-install` so it installs the recommended kernel itself instead of prompting.
- preflight and `doctor --fix` now call `SystemStart()` unconditionally instead of only when the service is stopped. Turns out `system start` rechecks the kernel every time and no-ops fast if already set, so this is cheap and it's the only way to catch a service that's up but has no kernel (the exact state you're left in after the hung prompt).
- `doctor --fix` reports kernel status as its own check now instead of lumping it in with "container system service".

Plain `doctor` doesn't mutate anything so it can't verify the kernel without `--fix` just hints at it.

Added a test for the new flag. `go build`, `vet`, `test ./...` all green locally.