### PR TITLE
feat: add host bind mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Containers are great for packaging software, and kiac depends on them. The point
 - 🔒 **Hardware-grade isolation** — each node is one lightweight VM with its own kernel and cgroups, not namespaces sharing a daemon.
 - 📊 **Metrics out of the box** — `kubectl top nodes` works the moment the cluster is up. metrics-server ships preconfigured.
 - 💾 **PVCs that just bind** — a default StorageClass (local-path-provisioner) is installed on create, so StatefulSets and `volumeClaimTemplates` work immediately.
+- **Host bind mounts** — repeatable `--mount` options expose macOS directories at matching paths in every kubeadm or k3s node, ready for Kubernetes `hostPath` volumes.
 - ⚖️ **`type: LoadBalancer` works** — kiac-lb ships by default: a tiny systemd loop inside the control-plane VM assigns node IPs to Services in about two seconds, shares one IP across Services when ports don't collide, and heals itself after node restarts. No pods, no webhooks, no `<pending>`, no tunnels.
 - 🌐 **Direct networking** — every node gets a routable IP on macOS 26+. Hit NodePorts directly, no port-mapping flags; a tiny embedded node-local edge proxy terminates external TCP first so large uploads from sibling VMs do not hit vmnet's TSO forwarding bug.
 - 🧱 **Multi-node, day one** — `--workers N` gives a real topology: scheduling, cross-node pod networking, node failures you can practice on.
@@ -235,6 +236,7 @@ kiac create cluster --k8s-version 1.34       # pick your Kubernetes (1.32-1.36 p
 kiac create cluster --distro k3s --workers 1 # rancher/k3s nodes: sqlite datastore, up in under a minute
 kiac create cluster --cni cilium --kernel full --workers 2   # Cilium eBPF on the full node kernel
 kiac create cluster --config cluster.yaml    # declarative; explicit flags override the file (see examples/cluster.yaml)
+kiac create cluster --mount type=bind,source="$PWD",target=/workspace,readonly # host directory in every node
 kiac ui                                      # local web console: manage clusters, kubectl Console per cluster
 kiac get clusters                            # -o wide for versions/age, -o json for scripts
 kiac get nodes --name dev
@@ -266,6 +268,7 @@ Full guides and command reference live on the [docs site](https://saiyam1814.git
 | `--cni` | `kindnet` | pod network: `kindnet`, `cilium` (requires `--kernel full` and the `cilium` CLI on your PATH), or `none` to bring your own |
 | `--kernel` | Apple's stock kernel | `full` downloads the published kiac kernel (VXLAN, Geneve, br_netfilter, eBPF, WireGuard; sha-pinned, cached in `~/.kiac/kernels`), or pass a path to a kernel Image |
 | `--dns` | runtime default | nameserver IPs for the node VMs, repeatable up to 3 (resolv.conf's own limit); given, it replaces the runtime's default resolv.conf entirely rather than adding to it |
+| `--mount` | | bind a host directory into every node VM; repeat `type=bind,source=/host/path,target=/node/path[,readonly]`. Explicit CLI mounts replace config-file mounts |
 | `--cpus` | `4` | vCPUs per node VM |
 | `--memory` | `2G` | memory per worker VM (idle workers use a few hundred MB) |
 | `--cp-memory` | `4G` | memory for the control-plane VM (etcd, apiserver, and on single-node clusters every addon) |
@@ -286,6 +289,8 @@ Full guides and command reference live on the [docs site](https://saiyam1814.git
 </p>
 
 kiac drives the `apple/container` CLI to boot one lightweight VM per node from the standard `kindest/node` image (systemd, containerd, kubeadm preinstalled), initializes the control plane with `kubeadm`, joins the workers over the `vmnet` network, applies the kindnet CNI, and installs metrics-server, local-path storage, the built-in kiac-lb LoadBalancer, and the embedded node-local edge proxy by default. With `--distro k3s` the same VMs run `rancher/k3s` as PID 1 instead, and `--kernel full` boots every node on a published kernel build with the features overlay and eBPF CNIs need. It talks only to the `apple/container` runtime and never touches the Docker socket, so it coexists with Docker Desktop, Rancher Desktop, kind, and k3d.
+
+Host bind mounts use ordinary `container run`, not `container machine`; `/Users` is therefore not shared automatically. A configured mount is attached independently to every node and remains attached when that container is stopped and started or resumed. See [Storage & metrics](https://saiyam1814.github.io/kiac/docs/storage-and-metrics.html#host-bind-mounts) for the required Kubernetes `hostPath` layer and security implications.
 
 ## Roadmap
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -23,7 +23,8 @@ var createClusterCmd = &cobra.Command{
 	Example: `  kiac create cluster
   kiac create cluster --name dev --workers 2
   kiac create cluster --memory 8G --cpus 4
-  kiac create cluster --distro k3s --workers 1`,
+  kiac create cluster --distro k3s --workers 1
+  kiac create cluster --mount type=bind,source="$PWD",target=/workspace,readonly`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ui.Banner(Version)
 		// Seed the typed family from the string flag (default ipv4) before
@@ -116,6 +117,7 @@ func init() {
 	f.StringVar(&createIPFamily, "ip-family", "ipv4", "IP family for pods, Services, and nodes: ipv4, dual (IPv4-primary + IPv6), or ipv6 (IPv6-primary; needs the full kernel, auto-selected)")
 	f.StringVar(&createKernel, "kernel", "", "custom node kernel: 'full' (downloads the published kiac kernel with VXLAN/eBPF/br_netfilter) or a path to a kernel Image")
 	f.StringSliceVar(&createCfg.DNS, "dns", nil, "nameserver IPs for the node VMs, repeatable up to 3 (resolv.conf's own limit); overrides the runtime's default resolv.conf entirely rather than adding to it")
+	f.Var(&createCfg.Mounts, "mount", "bind a host directory into every node VM (type=bind,source=/host/path,target=/node/path[,readonly]); repeatable")
 	f.StringVar(&createCfg.CPUs, "cpus", "4", "vCPUs per node VM")
 	f.StringVar(&createCfg.Memory, "memory", "2G", "memory per worker VM (idle workers use a few hundred MB)")
 	f.StringVar(&createCfg.CPMemory, "cp-memory", "4G", "memory for the control-plane VM (etcd, apiserver, and on single-node clusters every addon)")

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -64,6 +64,7 @@ kiac create cluster --name dev --workers 2
 kiac create cluster --memory 8G --cpus 4
 kiac create cluster --distro k3s --workers 1
 kiac create cluster --cni cilium --kernel full
+kiac create cluster --mount type=bind,source="$PWD",target=/workspace,readonly
 kiac create cluster --config cluster.yaml</code></pre>
   <table>
     <tr><th>Flag</th><th>Default</th><th>Description</th></tr>
@@ -76,6 +77,7 @@ kiac create cluster --config cluster.yaml</code></pre>
     <tr><td><code>--cni</code></td><td><code>kindnet</code></td><td>pod network: <code>kindnet</code>, <code>cilium</code> (needs <code>--kernel full</code> and the <code>cilium</code> CLI), or <code>none</code> (bring your own). kubeadm distro only; the k3s path always gets kindnet</td></tr>
     <tr><td><code>--kernel</code></td><td></td><td>custom node kernel: <code>full</code> (downloads the published kiac kernel with VXLAN/eBPF/br_netfilter, cached in <code>~/.kiac/kernels/</code>) or a path to an arm64 boot Image. See <a href="cilium.html">Cilium &amp; the full kernel</a></td></tr>
     <tr><td><code>--dns</code></td><td>runtime default</td><td>nameserver IPs for the node VMs, repeatable up to 3 (resolv.conf's own limit): <code>--dns 1.1.1.1 --dns 8.8.8.8</code>. Given, it replaces the runtime's default resolv.conf entirely rather than adding to it (see <a href="troubleshooting.html#vpn-dns">Troubleshooting</a>)</td></tr>
+    <tr><td><code>--mount</code></td><td></td><td>bind a host directory into every node VM; repeat <code>type=bind,source=/host/path,target=/node/path[,readonly]</code>. Explicit CLI mounts replace config-file mounts</td></tr>
     <tr><td><code>--cpus</code></td><td><code>4</code></td><td>vCPUs per node VM</td></tr>
     <tr><td><code>--memory</code></td><td><code>2G</code></td><td>memory per worker VM (idle workers use a few hundred MB)</td></tr>
     <tr><td><code>--cp-memory</code></td><td><code>4G</code></td><td>memory for the control-plane VM (etcd, apiserver, and on single-node clusters every addon)</td></tr>

--- a/docs/docs/config-file.html
+++ b/docs/docs/config-file.html
@@ -68,6 +68,11 @@ k8sVersion: "1.36"   <span class="c"># Kubernetes minor ("1.36") or exact patch 
 cni: kindnet         <span class="c"># pod network: kindnet, or none to bring your own</span>
 <span class="c"># dns: [1.1.1.1, 8.8.8.8]  # node VM nameservers, up to 3; replaces the</span>
 <span class="c">#                    # runtime default resolv.conf entirely when set</span>
+<span class="c"># Host directories mounted into every node VM:</span>
+mounts:
+  - source: /Users/me/project
+    target: /workspace
+    readOnly: true
 cpus: "4"            <span class="c"># vCPUs per node VM (quote it: YAML reads bare 4 as a number)</span>
 memory: 4G           <span class="c"># memory per worker VM</span>
 wait: 5m             <span class="c"># timeout for nodes to become Ready</span>
@@ -90,6 +95,7 @@ addons:
     <tr><td><code>image</code></td><td>string</td><td>resolved from <code>k8sVersion</code></td><td><code>--image</code></td></tr>
     <tr><td><code>cni</code></td><td>string</td><td><code>kindnet</code></td><td><code>--cni</code></td></tr>
     <tr><td><code>dns</code></td><td>list of IPs (max 3)</td><td>runtime default</td><td><code>--dns</code></td></tr>
+    <tr><td><code>mounts</code></td><td>list of <code>source</code>, <code>target</code>, <code>readOnly</code></td><td>none</td><td><code>--mount</code></td></tr>
     <tr><td><code>cpus</code></td><td>string</td><td><code>"4"</code></td><td><code>--cpus</code></td></tr>
     <tr><td><code>memory</code></td><td>string</td><td><code>2G</code></td><td><code>--memory</code> (worker VMs)</td></tr>
     <tr><td><code>cpMemory</code></td><td>string</td><td><code>4G</code></td><td><code>--cp-memory</code> (control-plane VM)</td></tr>
@@ -107,6 +113,7 @@ addons:
     <li>Addon keys are positive (<code>storage: true</code>) even though the flags are negative (<code>--no-storage</code>); kiac maps between them.</li>
     <li>Quote <code>cpus</code>: YAML parses a bare <code>4</code> as a number, and the field is a string.</li>
     <li>An empty file is valid and means "all defaults".</li>
+    <li>Each mount source must be an existing absolute macOS directory and each target an absolute Linux path. Targets must be unique. Commas are unsupported because they delimit Apple Container's mount fields.</li>
     <li><code>--distro</code> and <code>--kernel</code> are <b>not config file keys yet</b>; pass them on the command line (they compose with <code>--config</code> for everything else).</li>
   </ul>
 
@@ -121,6 +128,7 @@ addons:
 kiac create cluster --config cluster.yaml --workers 3
 <span class="c"># result: name dev (from file), workers 3 (flag overrides file)</span></code></pre>
   <p>The distinction is "explicitly set", not "different from the default": passing <code>--workers 0</code> on the command line beats <code>workers: 2</code> in the file.</p>
+  <p>For repeatable mounts, one or more explicit <code>--mount</code> flags replace the complete <code>mounts</code> list from the file; KIAC never silently combines two lists with potentially conflicting targets.</p>
 
   <div class="pn">
     <a href="storage-and-metrics.html"><span>Previous</span>Storage &amp; metrics</a>

--- a/docs/docs/storage-and-metrics.html
+++ b/docs/docs/storage-and-metrics.html
@@ -85,6 +85,35 @@ kubectl get pvc data    <span class="c"># Pending until a pod uses it (WaitForFi
     <li>Skip installation with <code>--no-storage</code> (or <code>addons.storage: false</code> in a <a href="config-file.html">config file</a>).</li>
   </ul>
 
+  <h2 id="host-bind-mounts">Host bind mounts and hostPath</h2>
+  <p>Use a repeatable <code>--mount</code> to make an existing macOS directory visible inside every node VM:</p>
+  <pre><code>kiac create cluster --name dev \
+  --mount type=bind,source=/Users/me/project,target=/workspace,readonly \
+  --mount type=bind,source=/Users/me/data,target=/data</code></pre>
+  <p>The data path has two required layers:</p>
+  <pre><code>macOS path
+  -&gt; Apple Container bind mount into each node VM
+    -&gt; Kubernetes hostPath
+      -&gt; pod volumeMount</code></pre>
+  <pre><code>volumes:
+  - name: source
+    hostPath:
+      path: /workspace
+      type: Directory
+containers:
+  - name: app
+    volumeMounts:
+      - name: source
+        mountPath: /workspace</code></pre>
+  <ul>
+    <li>KIAC uses ordinary <code>container run</code>, not <code>container machine</code>, so the host's <code>/Users</code> directory is not shared automatically.</li>
+    <li>Every configured directory is mounted independently into the control plane/server and every worker/agent. A pod's <code>hostPath</code> is the target path inside whichever node schedules it.</li>
+    <li>Bind mounts expose host data to node VMs. Any workload allowed to use a writable <code>hostPath</code>, subject to filesystem permissions and admission policy, may modify host files; prefer <code>readonly</code> for source trees.</li>
+    <li>Concurrent writes from multiple nodes can be unsafe, especially for databases. Use node-local PVC storage or a suitable shared storage system instead.</li>
+    <li>Apple Container keeps mounts on the existing node container across stop/start and <code>kiac resume cluster</code>. The host source must still exist when the node starts.</li>
+    <li>Deleting a cluster removes its node VMs, not bind-mounted host data. Local-path PVC data is separate: it remains node-local and is deleted with its node VM.</li>
+  </ul>
+
   <h2 id="metrics">metrics-server</h2>
   <p>kiac installs metrics-server v0.8.1 by default, patched with <code>--kubelet-insecure-tls</code> because kubeadm-issued kubelet serving certificates are self-signed in local clusters. That is the standard tweak every local distribution needs, done for you.</p>
   <pre><code>kubectl top nodes

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -53,6 +53,13 @@ ipFamily: ipv4
 # resolver nodes use by default (see docs/docs/troubleshooting.html).
 # dns: [1.1.1.1, 8.8.8.8]
 
+# Host directories bind-mounted into every node VM. Kubernetes hostPath
+# volumes use the target path. Prefer readOnly for source trees.
+# mounts:
+#   - source: /Users/me/project
+#     target: /workspace
+#     readOnly: true
+
 # Resources per node VM. Quote cpus: YAML reads bare 4 as a number.
 cpus: "4"
 memory: 4G

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -14,6 +14,10 @@ ipFamily: ipv4       # ipv4 (default), dual (IPv4-primary + IPv6), or ipv6 (IPv6
                      # dual/ipv6 auto-select the full kernel (IPv6 netfilter) and need macOS 26+.
 # dns: [1.1.1.1, 8.8.8.8]  # node VM nameservers, up to 3; replaces the
                      # runtime default resolv.conf entirely when set
+# mounts:             # host directories mounted into every node VM
+#   - source: /Users/me/project
+#     target: /workspace
+#     readOnly: true
 cpus: "4"            # vCPUs per node VM (quote it: YAML reads bare 4 as a number)
 memory: 4G           # memory per node VM
 wait: 5m             # timeout for nodes to become Ready

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -114,6 +114,7 @@ type Config struct {
 	Kernel        string   // resolved kernel Image path; empty = runtime default
 	IPFamily      IPFamily // ipv4 (default), dual, or ipv6; non-ipv4 requires the full kernel
 	DNS           []string // node VM nameservers; empty = runtime default resolv.conf (see nodeDNS)
+	Mounts        runtime.Mounts
 	NoMetrics     bool
 	NoStorage     bool
 	NoLB          bool
@@ -191,6 +192,9 @@ func (m *Manager) Create(cfg Config) error {
 	if err := validateDNS(cfg); err != nil {
 		return err
 	}
+	if err := runtime.ValidateMounts(cfg.Mounts); err != nil {
+		return err
+	}
 
 	// Fail cilium prerequisites before any VM boots, not minutes later
 	// when the CNI step runs.
@@ -231,7 +235,7 @@ func (m *Manager) Create(cfg Config) error {
 			if n == cp && cfg.CPMemory != "" {
 				mem = cfg.CPMemory
 			}
-			if err := m.rt.RunDetached(runtime.RunOpts{Name: n, Image: cfg.Image, CPUs: cfg.CPUs, Memory: mem, Kernel: cfg.Kernel, DNS: dns}); err != nil {
+			if err := m.rt.RunDetached(kubeadmNodeRunOpts(cfg, n, mem, dns)); err != nil {
 				return err
 			}
 		}
@@ -465,6 +469,18 @@ func (m *Manager) Create(cfg Config) error {
 		warnAPIUnreachable(cp, cfg.Name, serverIP)
 	}
 	return nil
+}
+
+func kubeadmNodeRunOpts(cfg Config, nodeName, memory string, dns []string) runtime.RunOpts {
+	return runtime.RunOpts{
+		Name:   nodeName,
+		Image:  cfg.Image,
+		CPUs:   cfg.CPUs,
+		Memory: memory,
+		Kernel: cfg.Kernel,
+		DNS:    dns,
+		Mounts: cfg.Mounts,
+	}
 }
 
 // serverIP returns the control-plane address the host kubeconfig should

--- a/pkg/cluster/configfile.go
+++ b/pkg/cluster/configfile.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/saiyam1814/kiac/pkg/runtime"
 	"gopkg.in/yaml.v3"
 )
 
@@ -15,18 +16,19 @@ import (
 // fields distinguish "omitted" from an explicit zero value, and addon
 // toggles are positive booleans that Merge maps onto the No* fields.
 type FileConfig struct {
-	Name       string     `yaml:"name"`
-	Workers    *int       `yaml:"workers"`
-	K8sVersion string     `yaml:"k8sVersion"`
-	Image      string     `yaml:"image"`
-	CNI        string     `yaml:"cni"`
-	IPFamily   string     `yaml:"ipFamily"`
-	DNS        []string   `yaml:"dns"`
-	CPUs       string     `yaml:"cpus"`
-	Memory     string     `yaml:"memory"`
-	CPMemory   string     `yaml:"cpMemory"`
-	Wait       string     `yaml:"wait"`
-	Addons     FileAddons `yaml:"addons"`
+	Name       string         `yaml:"name"`
+	Workers    *int           `yaml:"workers"`
+	K8sVersion string         `yaml:"k8sVersion"`
+	Image      string         `yaml:"image"`
+	CNI        string         `yaml:"cni"`
+	IPFamily   string         `yaml:"ipFamily"`
+	DNS        []string       `yaml:"dns"`
+	Mounts     runtime.Mounts `yaml:"mounts"`
+	CPUs       string         `yaml:"cpus"`
+	Memory     string         `yaml:"memory"`
+	CPMemory   string         `yaml:"cpMemory"`
+	Wait       string         `yaml:"wait"`
+	Addons     FileAddons     `yaml:"addons"`
 }
 
 // FileAddons toggles the optional cluster addons. Omitted keys keep the
@@ -59,6 +61,13 @@ func LoadConfigFile(path string) (*FileConfig, error) {
 		}
 		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
 	}
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+		}
+		return nil, fmt.Errorf("parsing config file %s: multiple YAML documents are not supported", path)
+	}
 	return &fc, nil
 }
 
@@ -87,6 +96,9 @@ func (fc *FileConfig) Merge(cfg *Config, k8sVersion *string, changed func(string
 	}
 	if len(fc.DNS) > 0 && !changed("dns") {
 		cfg.DNS = fc.DNS
+	}
+	if len(fc.Mounts) > 0 && !changed("mount") {
+		cfg.Mounts = fc.Mounts
 	}
 	if fc.CPUs != "" && !changed("cpus") {
 		cfg.CPUs = fc.CPUs

--- a/pkg/cluster/configfile_test.go
+++ b/pkg/cluster/configfile_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/saiyam1814/kiac/pkg/runtime"
 )
 
 func writeConfig(t *testing.T, yaml string) string {
@@ -33,6 +35,10 @@ k8sVersion: "1.34"
 image: docker.io/kindest/node:v1.34.8
 cni: none
 dns: [192.168.64.1, 9.9.9.9]
+mounts:
+  - source: /Users/me/project files
+    target: /workspace
+    readOnly: true
 cpus: "8"
 memory: 8G
 wait: 10m
@@ -56,6 +62,9 @@ addons:
 				}
 				if len(fc.DNS) != 2 || fc.DNS[0] != "192.168.64.1" || fc.DNS[1] != "9.9.9.9" {
 					t.Errorf("dns = %q", fc.DNS)
+				}
+				if len(fc.Mounts) != 1 || fc.Mounts[0].Source != "/Users/me/project files" || fc.Mounts[0].Target != "/workspace" || !fc.Mounts[0].ReadOnly {
+					t.Errorf("mounts = %+v", fc.Mounts)
 				}
 				a := fc.Addons
 				if a.Metrics == nil || *a.Metrics || a.Storage == nil || *a.Storage || a.LoadBalancer == nil || *a.LoadBalancer || a.EdgeProxy == nil || *a.EdgeProxy {
@@ -96,6 +105,16 @@ addons:
 			name:    "unknown addon key",
 			yaml:    "addons:\n  metrics: true\n  dashboard: true\n",
 			wantErr: "dashboard",
+		},
+		{
+			name:    "unknown mount key",
+			yaml:    "mounts:\n  - source: /tmp/data\n    target: /data\n    mode: ro\n",
+			wantErr: "mode",
+		},
+		{
+			name:    "additional YAML document",
+			yaml:    "name: demo\n---\nmounts: []\n",
+			wantErr: "multiple YAML documents",
 		},
 		{
 			name:    "old flag names are unknown keys",
@@ -155,6 +174,7 @@ func TestMerge(t *testing.T) {
 		Image:      "docker.io/kindest/node:v1.34.8",
 		CNI:        "none",
 		DNS:        []string{"192.168.64.1", "9.9.9.9"},
+		Mounts:     runtime.Mounts{{Source: "/Users/me/project", Target: "/workspace", ReadOnly: true}},
 		CPUs:       "8",
 		Memory:     "8G",
 		Wait:       "10m",
@@ -185,6 +205,7 @@ func TestMerge(t *testing.T) {
 				Image:     "docker.io/kindest/node:v1.34.8",
 				CNI:       "none",
 				DNS:       []string{"192.168.64.1", "9.9.9.9"},
+				Mounts:    runtime.Mounts{{Source: "/Users/me/project", Target: "/workspace", ReadOnly: true}},
 				CPUs:      "8",
 				Memory:    "8G",
 				CPMemory:  "4G",
@@ -217,6 +238,7 @@ func TestMerge(t *testing.T) {
 				Image:     "docker.io/kindest/node:v1.34.8",
 				CNI:       "none",
 				DNS:       []string{"192.168.64.1", "9.9.9.9"},
+				Mounts:    runtime.Mounts{{Source: "/Users/me/project", Target: "/workspace", ReadOnly: true}},
 				CPUs:      "8",
 				Memory:    "8G",
 				CPMemory:  "4G",
@@ -235,6 +257,7 @@ func TestMerge(t *testing.T) {
 				Image:     "docker.io/kindest/node:v1.34.8",
 				CNI:       "none",
 				DNS:       []string{"192.168.64.1", "9.9.9.9"},
+				Mounts:    runtime.Mounts{{Source: "/Users/me/project", Target: "/workspace", ReadOnly: true}},
 				CPUs:      "8",
 				Memory:    "8G",
 				CPMemory:  "4G",
@@ -256,6 +279,29 @@ func TestMerge(t *testing.T) {
 				Image:     "docker.io/kindest/node:v1.34.8",
 				CNI:       "none",
 				DNS:       []string{"10.0.0.53"},
+				Mounts:    runtime.Mounts{{Source: "/Users/me/project", Target: "/workspace", ReadOnly: true}},
+				CPUs:      "8",
+				Memory:    "8G",
+				CPMemory:  "4G",
+				NoMetrics: true, NoStorage: true, NoLB: true, NoEdgeProxy: true,
+				Observability: true, Gateway: true,
+				WaitTimeout: 10 * time.Minute,
+			},
+			wantVersion: "1.34",
+		},
+		{
+			name:    "explicit mount flags override file",
+			file:    full,
+			changed: map[string]bool{"mount": true},
+			mutate: func(cfg *Config, v *string) {
+				cfg.Mounts = runtime.Mounts{{Source: "/cli", Target: "/data"}}
+			},
+			wantCfg: Config{
+				Name: "demo", Workers: 3,
+				Image:     "docker.io/kindest/node:v1.34.8",
+				CNI:       "none",
+				DNS:       []string{"192.168.64.1", "9.9.9.9"},
+				Mounts:    runtime.Mounts{{Source: "/cli", Target: "/data"}},
 				CPUs:      "8",
 				Memory:    "8G",
 				CPMemory:  "4G",

--- a/pkg/cluster/k3s.go
+++ b/pkg/cluster/k3s.go
@@ -163,6 +163,7 @@ func k3sServerRunOpts(cfg Config, nodeName, token string, dns []string) runtime.
 		Kernel:     cfg.Kernel,
 		Args:       bootArgs,
 		DNS:        dns,
+		Mounts:     cfg.Mounts,
 	}
 }
 
@@ -179,6 +180,7 @@ func k3sAgentRunOpts(cfg Config, nodeName string, env []string, dns []string) ru
 		Kernel:     cfg.Kernel,
 		Args:       bootArgs,
 		DNS:        dns,
+		Mounts:     cfg.Mounts,
 	}
 }
 
@@ -238,6 +240,9 @@ func (m *Manager) CreateK3s(cfg Config) error {
 		return err
 	}
 	if err := validateDNS(cfg); err != nil {
+		return err
+	}
+	if err := runtime.ValidateMounts(cfg.Mounts); err != nil {
 		return err
 	}
 	if cfg.family() == IPv6 {

--- a/pkg/cluster/k3s_test.go
+++ b/pkg/cluster/k3s_test.go
@@ -1,8 +1,11 @@
 package cluster
 
 import (
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/saiyam1814/kiac/pkg/runtime"
 )
 
 func TestResolveK3sImage(t *testing.T) {
@@ -107,6 +110,7 @@ func TestK3sRunOptsCarryKernel(t *testing.T) {
 		Memory:   "2G",
 		CPMemory: "4G",
 		Kernel:   "/tmp/kiac-kernel-full",
+		Mounts:   runtime.Mounts{{Source: "/host", Target: "/workspace", ReadOnly: true}},
 	}
 	dns := []string{"192.168.64.1", "1.1.1.1"}
 	server := k3sServerRunOpts(cfg, "kiac-dev-control-plane", "tok123", dns)
@@ -122,6 +126,9 @@ func TestK3sRunOptsCarryKernel(t *testing.T) {
 	if strings.Join(server.DNS, ",") != "192.168.64.1,1.1.1.1" {
 		t.Errorf("server DNS = %q", server.DNS)
 	}
+	if !slices.Equal(server.Mounts, cfg.Mounts) {
+		t.Errorf("server Mounts = %+v, want %+v", server.Mounts, cfg.Mounts)
+	}
 
 	env := k3sAgentEnv("192.168.64.5", "tok123")
 	agent := k3sAgentRunOpts(cfg, "kiac-dev-worker-1", env, dns)
@@ -136,6 +143,9 @@ func TestK3sRunOptsCarryKernel(t *testing.T) {
 	}
 	if strings.Join(agent.Env, "\n") != strings.Join(env, "\n") {
 		t.Errorf("agent Env = %q, want %q", agent.Env, env)
+	}
+	if !slices.Equal(agent.Mounts, cfg.Mounts) {
+		t.Errorf("agent Mounts = %+v, want %+v", agent.Mounts, cfg.Mounts)
 	}
 }
 

--- a/pkg/cluster/mount_test.go
+++ b/pkg/cluster/mount_test.go
@@ -1,0 +1,34 @@
+package cluster
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/saiyam1814/kiac/pkg/runtime"
+)
+
+func TestKubeadmNodeRunOptsCarryMounts(t *testing.T) {
+	cfg := Config{
+		Image:    "docker.io/kindest/node:v1.36.0",
+		CPUs:     "4",
+		Memory:   "2G",
+		CPMemory: "4G",
+		Kernel:   "/tmp/kernel",
+		Mounts:   runtime.Mounts{{Source: "/host", Target: "/workspace", ReadOnly: true}},
+	}
+	dns := []string{"1.1.1.1"}
+
+	controlPlane := kubeadmNodeRunOpts(cfg, "kiac-dev-control-plane", cfg.CPMemory, dns)
+	worker := kubeadmNodeRunOpts(cfg, "kiac-dev-worker-1", cfg.Memory, dns)
+	for name, opts := range map[string]runtime.RunOpts{"control plane": controlPlane, "worker": worker} {
+		if !slices.Equal(opts.Mounts, cfg.Mounts) {
+			t.Errorf("%s Mounts = %+v, want %+v", name, opts.Mounts, cfg.Mounts)
+		}
+		if !slices.Equal(opts.DNS, dns) {
+			t.Errorf("%s DNS = %q, want %q", name, opts.DNS, dns)
+		}
+	}
+	if controlPlane.Memory != "4G" || worker.Memory != "2G" {
+		t.Errorf("memory = control plane %q, worker %q", controlPlane.Memory, worker.Memory)
+	}
+}

--- a/pkg/runtime/container.go
+++ b/pkg/runtime/container.go
@@ -119,6 +119,7 @@ type RunOpts struct {
 	Kernel     string   // custom kernel Image path (--kernel), empty = bundled default
 	Args       []string // command arguments appended after the image
 	DNS        []string // nameserver IPs (--dns); empty keeps the runtime default resolv.conf
+	Mounts     []Mount  // host directory bind mounts (--mount)
 }
 
 // RunDetached boots a node VM. The kindest/node entrypoint brings up
@@ -149,6 +150,9 @@ func (c *Client) RunDetached(o RunOpts) error {
 	}
 	for _, d := range o.DNS {
 		args = append(args, "--dns", d)
+	}
+	for _, mount := range o.Mounts {
+		args = append(args, "--mount", mount.String())
 	}
 	if o.Entrypoint != "" {
 		args = append(args, "--entrypoint", o.Entrypoint)

--- a/pkg/runtime/container_test.go
+++ b/pkg/runtime/container_test.go
@@ -128,6 +128,35 @@ func TestRunDetachedOmitsDNSWhenUnset(t *testing.T) {
 	}
 }
 
+func TestRunDetachedPassesMountsBeforeImage(t *testing.T) {
+	argsFile := filepath.Join(t.TempDir(), "args")
+	client := fakeContainerClient(t, "--cap-add\n", argsFile)
+
+	err := client.RunDetached(RunOpts{
+		Name:  "kiac-test-control-plane",
+		Image: "example.invalid/node:v1",
+		Mounts: []Mount{
+			{Source: "/Users/me/project files", Target: "/workspace"},
+			{Source: "/Users/me/data", Target: "/data", ReadOnly: true},
+		},
+		Args: []string{"server"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readArgLines(t, argsFile)
+	want := []string{
+		"run", "-d", "--name", "kiac-test-control-plane", "--cap-add", "ALL",
+		"--mount", "type=bind,source=/Users/me/project files,target=/workspace",
+		"--mount", "type=bind,source=/Users/me/data,target=/data,readonly",
+		"example.invalid/node:v1", "server",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("run args = %q, want %q", got, want)
+	}
+}
+
 func TestValidateNodeRuntimeVersion(t *testing.T) {
 	for _, version := range []string{"0.8.0", "1.0.0", "1.1.0", "1.2.1", "1.2.2", "2.0.0"} {
 		if err := ValidateNodeRuntimeVersion(version); err != nil {
@@ -164,4 +193,13 @@ func readArgs(t *testing.T, path string) []string {
 		t.Fatal(err)
 	}
 	return strings.Fields(string(raw))
+}
+
+func readArgLines(t *testing.T, path string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimSuffix(string(raw), "\n"), "\n")
 }

--- a/pkg/runtime/mount.go
+++ b/pkg/runtime/mount.go
@@ -1,0 +1,128 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Mount describes a host directory bind-mounted into a node VM.
+type Mount struct {
+	Source   string `yaml:"source"`
+	Target   string `yaml:"target"`
+	ReadOnly bool   `yaml:"readOnly"`
+}
+
+// String returns Apple's container run --mount value.
+func (m Mount) String() string {
+	s := "type=bind,source=" + m.Source + ",target=" + m.Target
+	if m.ReadOnly {
+		s += ",readonly"
+	}
+	return s
+}
+
+// Mounts is a repeatable pflag.Value for Docker-style --mount specifications.
+// Set appends rather than replaces so each --mount occurrence is preserved.
+type Mounts []Mount
+
+func (m *Mounts) Set(value string) error {
+	mount, err := ParseMount(value)
+	if err != nil {
+		return err
+	}
+	*m = append(*m, mount)
+	return nil
+}
+
+func (m *Mounts) String() string {
+	if m == nil {
+		return ""
+	}
+	values := make([]string, len(*m))
+	for i, mount := range *m {
+		values[i] = mount.String()
+	}
+	return strings.Join(values, ";")
+}
+
+func (*Mounts) Type() string { return "mount" }
+
+// ParseMount parses the long-form syntax accepted by Apple Container.
+func ParseMount(value string) (Mount, error) {
+	var mount Mount
+	seen := make(map[string]bool)
+	for _, field := range strings.Split(value, ",") {
+		key, val, hasValue := strings.Cut(field, "=")
+		key = strings.TrimSpace(key)
+		if seen[key] {
+			return Mount{}, fmt.Errorf("invalid mount %q: duplicate %q field", value, key)
+		}
+		seen[key] = true
+		switch key {
+		case "type":
+			if !hasValue || val != "bind" {
+				return Mount{}, fmt.Errorf("invalid mount %q: type must be bind", value)
+			}
+		case "source":
+			if !hasValue || val == "" {
+				return Mount{}, fmt.Errorf("invalid mount %q: source is required", value)
+			}
+			mount.Source = val
+		case "target":
+			if !hasValue || val == "" {
+				return Mount{}, fmt.Errorf("invalid mount %q: target is required", value)
+			}
+			mount.Target = val
+		case "readonly":
+			if hasValue {
+				return Mount{}, fmt.Errorf("invalid mount %q: readonly does not take a value", value)
+			}
+			mount.ReadOnly = true
+		default:
+			return Mount{}, fmt.Errorf("invalid mount %q: unknown field %q", value, key)
+		}
+	}
+	if !seen["type"] {
+		return Mount{}, fmt.Errorf("invalid mount %q: type=bind is required", value)
+	}
+	if mount.Source == "" {
+		return Mount{}, fmt.Errorf("invalid mount %q: source is required", value)
+	}
+	if mount.Target == "" {
+		return Mount{}, fmt.Errorf("invalid mount %q: target is required", value)
+	}
+	return mount, nil
+}
+
+// ValidateMounts checks every mount before KIAC creates a node VM.
+func ValidateMounts(mounts []Mount) error {
+	targets := make(map[string]int, len(mounts))
+	for i, mount := range mounts {
+		label := fmt.Sprintf("mount %d (source %q, target %q)", i+1, mount.Source, mount.Target)
+		if !filepath.IsAbs(mount.Source) {
+			return fmt.Errorf("invalid %s: source must be an absolute host path", label)
+		}
+		if strings.Contains(mount.Source, ",") || strings.Contains(mount.Target, ",") {
+			return fmt.Errorf("invalid %s: commas are not supported in mount paths by Apple Container's --mount syntax", label)
+		}
+		info, err := os.Stat(mount.Source)
+		if err != nil {
+			return fmt.Errorf("invalid %s: source is not accessible: %w", label, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("invalid %s: source must be a directory", label)
+		}
+		if !path.IsAbs(mount.Target) {
+			return fmt.Errorf("invalid %s: target must be an absolute Linux path", label)
+		}
+		target := path.Clean(mount.Target)
+		if previous, exists := targets[target]; exists {
+			return fmt.Errorf("invalid %s: target duplicates mount %d", label, previous)
+		}
+		targets[target] = i + 1
+	}
+	return nil
+}

--- a/pkg/runtime/mount_test.go
+++ b/pkg/runtime/mount_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseMount(t *testing.T) {
+	mount, err := ParseMount("type=bind,source=/Users/me/project files,target=/workspace,readonly")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := Mount{Source: "/Users/me/project files", Target: "/workspace", ReadOnly: true}
+	if !reflect.DeepEqual(mount, want) {
+		t.Fatalf("mount = %+v, want %+v", mount, want)
+	}
+}
+
+func TestMountsSetAppends(t *testing.T) {
+	var mounts Mounts
+	for _, value := range []string{
+		"type=bind,source=/one,target=/workspace",
+		"type=bind,source=/two,target=/data,readonly",
+	} {
+		if err := mounts.Set(value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(mounts) != 2 || mounts[0].Target != "/workspace" || !mounts[1].ReadOnly {
+		t.Fatalf("mounts = %+v", mounts)
+	}
+}
+
+func TestParseMountRejectsInvalidSyntax(t *testing.T) {
+	for _, tc := range []struct {
+		name, value, want string
+	}{
+		{"missing type", "source=/host,target=/node", "type=bind is required"},
+		{"wrong type", "type=volume,source=/host,target=/node", "type must be bind"},
+		{"missing source", "type=bind,target=/node", "source is required"},
+		{"missing target", "type=bind,source=/host", "target is required"},
+		{"unknown field", "type=bind,source=/host,target=/node,bind-propagation=rshared", "unknown field"},
+		{"readonly value", "type=bind,source=/host,target=/node,readonly=true", "does not take a value"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseMount(tc.value)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateMounts(t *testing.T) {
+	source := t.TempDir()
+	file := filepath.Join(source, "file")
+	if err := os.WriteFile(file, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(source, "missing")
+
+	for _, tc := range []struct {
+		name   string
+		mounts []Mount
+		want   string
+	}{
+		{"valid", []Mount{{Source: source, Target: "/workspace"}}, ""},
+		{"relative source", []Mount{{Source: "relative", Target: "/workspace"}}, "absolute host path"},
+		{"missing source", []Mount{{Source: missing, Target: "/workspace"}}, "source is not accessible"},
+		{"file source", []Mount{{Source: file, Target: "/workspace"}}, "source must be a directory"},
+		{"relative target", []Mount{{Source: source, Target: "workspace"}}, "absolute Linux path"},
+		{"duplicate target", []Mount{{Source: source, Target: "/workspace"}, {Source: source, Target: "/workspace/"}}, "duplicates mount 1"},
+		{"comma in source", []Mount{{Source: source + ",data", Target: "/workspace"}}, "commas are not supported"},
+		{"comma in target", []Mount{{Source: source, Target: "/work,space"}}, "commas are not supported"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMounts(tc.mounts)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/test/e2e/hostpath.yaml
+++ b/test/e2e/hostpath.yaml
@@ -1,19 +1,27 @@
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: hostpath
   namespace: kiac-e2e
 spec:
-  restartPolicy: Never
-  containers:
-    - name: hostpath
-      image: docker.io/library/busybox:1.37.0
-      command: [sh, -c, "sleep 86400"]
-      volumeMounts:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hostpath
+  template:
+    metadata:
+      labels:
+        app: hostpath
+    spec:
+      containers:
+        - name: hostpath
+          image: docker.io/library/busybox:1.37.0
+          command: [sh, -c, "sleep 86400"]
+          volumeMounts:
+            - name: host
+              mountPath: /host
+      volumes:
         - name: host
-          mountPath: /host
-  volumes:
-    - name: host
-      hostPath:
-        path: /kiac-e2e-host
-        type: Directory
+          hostPath:
+            path: /kiac-e2e-host
+            type: Directory

--- a/test/e2e/hostpath.yaml
+++ b/test/e2e/hostpath.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpath
+  namespace: kiac-e2e
+spec:
+  restartPolicy: Never
+  containers:
+    - name: hostpath
+      image: docker.io/library/busybox:1.37.0
+      command: [sh, -c, "sleep 86400"]
+      volumeMounts:
+        - name: host
+          mountPath: /host
+  volumes:
+    - name: host
+      hostPath:
+        path: /kiac-e2e-host
+        type: Directory

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -17,6 +17,7 @@ CURRENT_CONTEXT=""
 CURRENT_NODES=""
 TRAFFIC_POD=""
 CURRENT_MOUNT_DIR=""
+UPLOAD_NODE_PORT=""
 
 umask 077
 mkdir -p "$(dirname "${TRAFFIC_BIN}")" "$(dirname "${KIAC_E2E_STATE_FILE}")" "$(dirname "${KUBECONFIG}")"
@@ -179,7 +180,7 @@ test_upload() {
     return 1
   }
   container exec "${sender}" /tmp/kiac-e2e-traffic upload \
-    --url "http://$(url_host "${ip}"):32080/upload" --bytes 1048576
+    --url "http://$(url_host "${ip}"):${UPLOAD_NODE_PORT}/upload" --bytes 1048576
 }
 
 test_gateway() {
@@ -309,10 +310,11 @@ run_cluster() {
   done
 
   k apply -f "${ROOT}/test/e2e/workload.yaml"
+  UPLOAD_NODE_PORT=$(k -n kiac-e2e get service upload-server -o jsonpath='{.spec.ports[0].nodePort}')
   k apply -f "${ROOT}/test/e2e/hostpath.yaml"
-  k -n kiac-e2e wait --for=condition=Ready pod/hostpath --timeout=180s
-  [[ "$(k -n kiac-e2e exec hostpath -- cat /host/sentinel | tr -d '\r\n')" == host-sentinel ]]
-  k -n kiac-e2e exec hostpath -- sh -c 'printf pod-write > /host/from-pod'
+  k -n kiac-e2e rollout status deployment/hostpath --timeout=180s
+  [[ "$(k -n kiac-e2e exec deployment/hostpath -- cat /host/sentinel | tr -d '\r\n')" == host-sentinel ]]
+  k -n kiac-e2e exec deployment/hostpath -- sh -c 'printf pod-write > /host/from-pod'
   [[ "$(cat "${mount_dir}/from-pod")" == pod-write ]]
   k -n kiac-e2e patch deployment upload-server --type=merge \
     -p "{\"spec\":{\"template\":{\"spec\":{\"nodeSelector\":{\"kubernetes.io/hostname\":\"${target}\"}}}}}"
@@ -327,9 +329,9 @@ run_cluster() {
   sleep 5
 
   install_traffic_binary "${sender}"
-  test_upload "${sender}" "${ingress}" v4
+  retry 5 2 test_upload "${sender}" "${ingress}" v4
   if [[ "${family}" == dual ]]; then
-    test_upload "${sender}" "${ingress}" v6
+    retry 5 2 test_upload "${sender}" "${ingress}" v6
   fi
 
   local ingress_ip
@@ -363,7 +365,7 @@ run_cluster() {
       assert_k3s_node_addresses
       retry 30 1 edge_proxy_running "${sender}"
       install_traffic_binary "${sender}"
-      test_upload "${sender}" "${ingress}" v4
+      retry 5 2 test_upload "${sender}" "${ingress}" v4
 
       # Reproduce a host reboot without resetting vmnet for unrelated
       # clusters on the runner: halt every VM, then exercise the k3s-aware
@@ -379,8 +381,8 @@ run_cluster() {
       for node in ${CURRENT_NODES}; do
         [[ "$(container exec "${node}" cat /kiac-e2e-host/sentinel | tr -d '\r\n')" == host-sentinel ]]
       done
-      retry 30 2 k -n kiac-e2e exec hostpath -- test -f /host/from-pod
-      [[ "$(k -n kiac-e2e exec hostpath -- cat /host/from-pod | tr -d '\r\n')" == pod-write ]]
+      retry 30 2 k -n kiac-e2e exec deployment/hostpath -- test -f /host/from-pod
+      [[ "$(k -n kiac-e2e exec deployment/hostpath -- cat /host/from-pod | tr -d '\r\n')" == pod-write ]]
       for node in ${CURRENT_NODES}; do
         retry 30 1 edge_proxy_running "${node}"
       done
@@ -390,7 +392,7 @@ run_cluster() {
       start_traffic_server
       sleep 5
       install_traffic_binary "${sender}"
-      test_upload "${sender}" "${ingress}" v4
+      retry 5 2 test_upload "${sender}" "${ingress}" v4
       if [[ "${features}" == true ]]; then
         test_gateway
         test_observability
@@ -407,7 +409,7 @@ run_cluster() {
       # Reinstall only the test client; the product proxy in /usr/local/bin
       # must have persisted and is checked immediately above.
       install_traffic_binary "${sender}"
-      test_upload "${sender}" "${ingress}" v4
+      retry 5 2 test_upload "${sender}" "${ingress}" v4
     fi
   fi
 
@@ -420,6 +422,7 @@ run_cluster() {
   CURRENT_CLUSTER=""
   CURRENT_CONTEXT=""
   CURRENT_NODES=""
+  UPLOAD_NODE_PORT=""
 }
 
 printf 'Building kiac and the runtime traffic probe with %s\n' "$(go version)"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -16,6 +16,7 @@ CURRENT_CLUSTER=""
 CURRENT_CONTEXT=""
 CURRENT_NODES=""
 TRAFFIC_POD=""
+CURRENT_MOUNT_DIR=""
 
 umask 077
 mkdir -p "$(dirname "${TRAFFIC_BIN}")" "$(dirname "${KIAC_E2E_STATE_FILE}")" "$(dirname "${KUBECONFIG}")"
@@ -91,6 +92,9 @@ finish() {
       "${CURRENT_CLUSTER}" "${KIAC_BIN}" "${CURRENT_CLUSTER}" >&2
   else
     "${ROOT}/test/e2e/cleanup.sh"
+    if [[ -n "${CURRENT_MOUNT_DIR}" ]]; then
+      rm -rf -- "${CURRENT_MOUNT_DIR}"
+    fi
   fi
   exit "${status}"
 }
@@ -251,6 +255,10 @@ run_cluster() {
   local target="kiac-${name}-worker-2"
   local ingress="kiac-${name}-worker-3"
   local expected=$((workers + 1))
+  local mount_dir="${TMPDIR:-/tmp}/kiac-e2e-${RUN_ID}/${name} host data"
+  mkdir -p "${mount_dir}"
+  printf 'host-sentinel\n' > "${mount_dir}/sentinel"
+  CURRENT_MOUNT_DIR=${mount_dir}
 
   CURRENT_CLUSTER=${name}
   CURRENT_CONTEXT="kiac-${name}"
@@ -261,7 +269,8 @@ run_cluster() {
   done
   printf '%s\n' "${name}" >> "${KIAC_E2E_STATE_FILE}"
 
-  local create=(create cluster --name "${name}" --distro "${distro}" --workers "${workers}" --ip-family "${family}" --wait 8m)
+  local create=(create cluster --name "${name}" --distro "${distro}" --workers "${workers}" --ip-family "${family}" --wait 8m
+    --mount "type=bind,source=${mount_dir},target=/kiac-e2e-host")
   if [[ "${features}" == true ]]; then
     create+=(--gateway --observability)
   fi
@@ -285,6 +294,10 @@ run_cluster() {
   }
   retry 18 10 wait_for_metrics
 
+  for node in ${CURRENT_NODES}; do
+    [[ "$(container exec "${node}" cat /kiac-e2e-host/sentinel | tr -d '\r\n')" == host-sentinel ]]
+  done
+
   local i node
   for ((i = 0; i <= workers; i++)); do
     if [[ ${i} -eq 0 ]]; then
@@ -296,6 +309,11 @@ run_cluster() {
   done
 
   k apply -f "${ROOT}/test/e2e/workload.yaml"
+  k apply -f "${ROOT}/test/e2e/hostpath.yaml"
+  k -n kiac-e2e wait --for=condition=Ready pod/hostpath --timeout=180s
+  [[ "$(k -n kiac-e2e exec hostpath -- cat /host/sentinel | tr -d '\r\n')" == host-sentinel ]]
+  k -n kiac-e2e exec hostpath -- sh -c 'printf pod-write > /host/from-pod'
+  [[ "$(cat "${mount_dir}/from-pod")" == pod-write ]]
   k -n kiac-e2e patch deployment upload-server --type=merge \
     -p "{\"spec\":{\"template\":{\"spec\":{\"nodeSelector\":{\"kubernetes.io/hostname\":\"${target}\"}}}}}"
   k -n kiac-e2e rollout status deployment/upload-server --timeout=180s
@@ -341,6 +359,7 @@ run_cluster() {
       # node address cannot leave stale hostNetwork metadata behind.
       "${KIAC_BIN}" stop node worker-1 --name "${name}"
       "${KIAC_BIN}" start node worker-1 --name "${name}"
+      [[ "$(container exec "${sender}" cat /kiac-e2e-host/sentinel | tr -d '\r\n')" == host-sentinel ]]
       assert_k3s_node_addresses
       retry 30 1 edge_proxy_running "${sender}"
       install_traffic_binary "${sender}"
@@ -357,6 +376,11 @@ run_cluster() {
       "${KIAC_BIN}" resume cluster --name "${name}" --wait 8m
       k wait --for=condition=Ready nodes --all --timeout=300s
       assert_k3s_node_addresses
+      for node in ${CURRENT_NODES}; do
+        [[ "$(container exec "${node}" cat /kiac-e2e-host/sentinel | tr -d '\r\n')" == host-sentinel ]]
+      done
+      retry 30 2 k -n kiac-e2e exec hostpath -- test -f /host/from-pod
+      [[ "$(k -n kiac-e2e exec hostpath -- cat /host/from-pod | tr -d '\r\n')" == pod-write ]]
       for node in ${CURRENT_NODES}; do
         retry 30 1 edge_proxy_running "${node}"
       done
@@ -378,6 +402,7 @@ run_cluster() {
       "${KIAC_BIN}" start node worker-1 --name "${name}"
       k wait --for=condition=Ready "node/${sender}" --timeout=300s
       retry 30 1 edge_proxy_running "${sender}"
+      [[ "$(container exec "${sender}" cat /kiac-e2e-host/sentinel | tr -d '\r\n')" == host-sentinel ]]
       # The node VM keeps its root disk but receives a fresh /tmp on boot.
       # Reinstall only the test client; the product proxy in /usr/local/bin
       # must have persisted and is checked immediately above.
@@ -387,6 +412,10 @@ run_cluster() {
   fi
 
   "${KIAC_BIN}" delete cluster --name "${name}"
+  [[ "$(cat "${mount_dir}/sentinel")" == host-sentinel ]]
+  [[ "$(cat "${mount_dir}/from-pod")" == pod-write ]]
+  rm -rf -- "${mount_dir}"
+  CURRENT_MOUNT_DIR=""
   forget_cluster "${name}"
   CURRENT_CLUSTER=""
   CURRENT_CONTEXT=""

--- a/test/e2e/workload.yaml
+++ b/test/e2e/workload.yaml
@@ -45,4 +45,3 @@ spec:
     - name: http
       port: 8080
       targetPort: http
-      nodePort: 32080


### PR DESCRIPTION
## Summary

- add repeatable `--mount type=bind,source=...,target=...[,readonly]` support and structured YAML mounts
- validate host sources and Linux targets before node creation, then propagate mounts to every kubeadm and k3s node
- document all-node, hostPath, security, storage, precedence, and lifecycle semantics
- add parser, config, argv, propagation, and Apple-silicon runtime smoke coverage

Explicit CLI mounts replace the complete config-file mount list. This follows KIAC's existing explicit-flag-over-config precedence and avoids silently merging conflicting targets.

## Validation

- `make ci`
- `go test ./...`
- `bash -n test/e2e/run.sh`
- `git diff --check`
- `make runtime-smoke PROFILE=quick` on Apple Container 1.3.1 / macOS 26.6.2
- isolated Apple Container probe: bidirectional bind-mount access survived container stop/start and `container system stop`/`container system start`

The runtime-smoke profile passed for both kubeadm and k3s with three workers each. It verified the bind on every node, pod reads and writes through Kubernetes `hostPath`, kubeadm worker stop/start, k3s worker stop/start and full-cluster resume, and host-data retention after cluster deletion.

The runtime run also exposed two pre-existing E2E flakes. This PR hardens the harness by allowing Kubernetes to allocate the upload workload NodePort, retrying the asynchronous edge-proxy upload assertion, and using a Deployment for the hostPath probe so Kubernetes recreates it after a full k3s restart.