### PR TITLE
fix: honor wait timeout during Cilium install

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Full guides and command reference live on the [docs site](https://saiyam1814.git
 | `--observability` | `false` | install Prometheus + Grafana + node-exporter, Grafana on a LoadBalancer IP |
 | `--gateway` | `false` | install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway |
 | `--config` | | cluster config YAML (see [`examples/cluster.yaml`](examples/cluster.yaml)); flags set explicitly on the command line override file values (`--distro` and `--kernel` are flags only for now) |
-| `--wait` | `5m` | node readiness timeout |
+| `--wait` | `5m` | timeout for each readiness step, including CNI installation |
 
 ## How it works
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -127,6 +127,6 @@ func init() {
 	f.BoolVar(&createCfg.NoEdgeProxy, "no-edge-proxy", false, "skip the node-local edge proxy that fixes large TCP uploads through NodePorts and LoadBalancers")
 	f.BoolVar(&createCfg.Observability, "observability", false, "install Prometheus + Grafana + node-exporter, Grafana on a LoadBalancer IP")
 	f.BoolVar(&createCfg.Gateway, "gateway", false, "install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway")
-	f.DurationVar(&createCfg.WaitTimeout, "wait", 5*time.Minute, "timeout for nodes to become ready")
+	f.DurationVar(&createCfg.WaitTimeout, "wait", 5*time.Minute, "timeout for each cluster readiness step, including CNI installation")
 	createCmd.AddCommand(createClusterCmd)
 }

--- a/docs/docs/cilium.html
+++ b/docs/docs/cilium.html
@@ -95,7 +95,7 @@ kiac create cluster --kernel full --cni none      <span class="c"># full kernel,
   <p><b>1. Install the prerequisite and create the cluster.</b> The addon flags compose: this exact command (Cilium + observability + Gateway API) builds the whole stack in about 1m37s on an M-series machine, kernel download included on the first run.</p>
   <pre><code>brew install cilium-cli
 kiac create cluster --name dev --workers 2 --cni cilium --kernel full --observability --gateway</code></pre>
-  <p>The kernel is fetched and verified before anything boots (cached after the first run), the VMs boot on it, and the <code>Installing CNI (Cilium)</code> step runs <code>cilium install --wait</code> against the new cluster.</p>
+  <p>The kernel is fetched and verified before anything boots (cached after the first run), the VMs boot on it, and the <code>Installing CNI (Cilium)</code> step runs <code>cilium install --wait</code> against the new cluster. Kiac passes its <code>--wait</code> value to Cilium as <code>--wait-duration</code>; raise it on slow links so large image pulls can finish.</p>
   <p><b>2. Check Cilium.</b> The same CLI kiac used is yours to drive:</p>
   <pre><code>cilium status --wait
 kubectl get nodes -o wide           <span class="c"># all Ready on the Cilium datapath</span>

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -87,7 +87,7 @@ kiac create cluster --config cluster.yaml</code></pre>
     <tr><td><code>--no-edge-proxy</code></td><td><code>false</code></td><td>skip the node-local edge proxy that fixes large TCP uploads through NodePorts and LoadBalancers</td></tr>
     <tr><td><code>--observability</code></td><td><code>false</code></td><td>install Prometheus + Grafana + node-exporter, Grafana on a LoadBalancer IP</td></tr>
     <tr><td><code>--gateway</code></td><td><code>false</code></td><td>install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway</td></tr>
-    <tr><td><code>--wait</code></td><td><code>5m</code></td><td>timeout for nodes to become ready</td></tr>
+    <tr><td><code>--wait</code></td><td><code>5m</code></td><td>timeout for each cluster readiness step, including CNI installation; passed to Cilium as <code>--wait-duration</code></td></tr>
   </table>
   <p>Version resolution: a minor like <code>1.34</code> uses kiac's digest-pinned node image (<code>kindest/node</code>, or <code>rancher/k3s</code> with <code>--distro k3s</code>); an exact patch matches the pin when it is the pinned patch, otherwise falls back to the matching upstream tag unpinned.</p>
   <p><code>--distro</code> and <code>--kernel</code> are CLI flags only for now; they are not <a href="config-file.html">config file</a> keys yet.</p>

--- a/examples/cilium-cluster.md
+++ b/examples/cilium-cluster.md
@@ -38,7 +38,8 @@ What happens, in order:
   WireGuard, and kprobes. See `kernel/README.md` for how it is built.
 - Every node VM boots on that kernel.
 - kiac runs `cilium install --wait` against the new cluster using your
-  host's cilium CLI, then installs the addons you asked for.
+  host's cilium CLI and passes the cluster's `--wait` budget through as
+  Cilium's `--wait-duration`, then installs the addons you asked for.
 
 With `--observability` and `--gateway` both added, the whole stack
 (Cilium, Prometheus, Grafana, Gateway API, Traefik) came up in 1m37s

--- a/pkg/cluster/cilium_test.go
+++ b/pkg/cluster/cilium_test.go
@@ -1,0 +1,33 @@
+package cluster
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestCiliumInstallArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    []string
+	}{
+		{
+			name:    "uses cluster wait budget",
+			timeout: 15 * time.Minute,
+			want:    []string{"install", "--wait", "--wait-duration", "15m0s"},
+		},
+		{
+			name: "keeps cilium default without a budget",
+			want: []string{"install", "--wait"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ciliumInstallArgs(tt.timeout); !slices.Equal(got, tt.want) {
+				t.Fatalf("ciliumInstallArgs(%s) = %q, want %q", tt.timeout, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -606,13 +606,21 @@ func (m *Manager) installCilium(cp string, cfg Config) error {
 			return err
 		}
 		defer os.Remove(kubeconfig)
-		cmd := exec.Command("cilium", "install", "--wait")
+		cmd := exec.Command("cilium", ciliumInstallArgs(cfg.WaitTimeout)...)
 		cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("cilium install: %w\n%s", err, strings.TrimSpace(string(out)))
 		}
 		return nil
 	})
+}
+
+func ciliumInstallArgs(waitTimeout time.Duration) []string {
+	args := []string{"install", "--wait"}
+	if waitTimeout > 0 {
+		args = append(args, "--wait-duration", waitTimeout.String())
+	}
+	return args
 }
 
 // preflight validates the host before any VM is booted.


### PR DESCRIPTION
## Summary
- pass Kiac's configured wait budget to Cilium as `--wait-duration`
- preserve Cilium's own default for zero-value library callers
- document that `--wait` covers CNI installation

## Verification
- `go test ./...`
- `GOTOOLCHAIN=go1.25.12 make ci`

Closes #41
