### PR TITLE
feat: support Kubernetes 1.37

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/saiyam1814/kiac/releases"><img src="https://img.shields.io/github/v/release/saiyam1814/kiac?color=326CE5&label=release" alt="release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-326CE5" alt="MIT"></a>
   <img src="https://img.shields.io/badge/platform-Apple%20silicon-555" alt="Apple silicon">
-  <img src="https://img.shields.io/badge/Kubernetes-1.32–1.36-326CE5" alt="Kubernetes 1.32-1.36">
+  <img src="https://img.shields.io/badge/Kubernetes-1.32–1.37-326CE5" alt="Kubernetes 1.32-1.37">
   <a href="https://saiyam1814.github.io/kiac/"><img src="https://img.shields.io/badge/website-kiac-326CE5" alt="website"></a>
   <a href="https://landscape.cncf.io/?search=kiac&amp;item=platform--certified-kubernetes-installer--kiac"><img src="https://img.shields.io/badge/CNCF%20Landscape-listed-0086FF" alt="Listed in the CNCF Landscape"></a>
 </p>
@@ -140,7 +140,7 @@ kiac create cluster --name dev --workers 2   # 1 control plane + 2 workers
 ```text
 ⬢ kiac · Kubernetes in Apple Containers
  ✓ Preflight checks (0.3s)
- ✓ Pulling node image kindest/node:v1.36.1 (8.4s)
+ ✓ Pulling node image kindest/node:v1.37.0 (8.4s)
  ✓ Booting 3 node VM(s) (9.8s)
  ✓ Initializing Kubernetes control plane (49.6s)
  ✓ Joining 2 worker(s) (13.5s)
@@ -208,9 +208,9 @@ The [integration labs](https://saiyam1814.github.io/kiac/docs/labs.html) also co
 ```bash
 $ kubectl get nodes -o wide
 NAME                     STATUS   ROLES           VERSION   INTERNAL-IP    KERNEL-VERSION    CONTAINER-RUNTIME
-kiac-dev-control-plane   Ready    control-plane   v1.36.1   192.168.64.2   6.12.28 (arm64)   containerd://2.3.1
-kiac-dev-worker-1        Ready    <none>          v1.36.1   192.168.64.3   6.12.28 (arm64)   containerd://2.3.1
-kiac-dev-worker-2        Ready    <none>          v1.36.1   192.168.64.4   6.12.28 (arm64)   containerd://2.3.1
+kiac-dev-control-plane   Ready    control-plane   v1.37.0   192.168.64.2   6.12.28 (arm64)   containerd://2.3.1
+kiac-dev-worker-1        Ready    <none>          v1.37.0   192.168.64.3   6.12.28 (arm64)   containerd://2.3.1
+kiac-dev-worker-2        Ready    <none>          v1.37.0   192.168.64.4   6.12.28 (arm64)   containerd://2.3.1
 
 $ kubectl top nodes
 NAME                     CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)
@@ -232,7 +232,7 @@ kiac doctor                                  # check your setup
 kiac doctor --fix                            # ...and auto-start the container service
 kiac create cluster                          # single node, everything included
 kiac create cluster --name dev --workers 2   # 1 control plane + 2 workers
-kiac create cluster --k8s-version 1.34       # pick your Kubernetes (1.32-1.36 pinned)
+kiac create cluster --k8s-version 1.34       # pick your Kubernetes (kubeadm 1.32-1.37 pinned)
 kiac create cluster --distro k3s --workers 1 # rancher/k3s nodes: sqlite datastore, up in under a minute
 kiac create cluster --cni cilium --kernel full --workers 2   # Cilium eBPF on the full node kernel
 kiac create cluster --config cluster.yaml    # declarative; explicit flags override the file (see examples/cluster.yaml)
@@ -262,7 +262,7 @@ Full guides and command reference live on the [docs site](https://saiyam1814.git
 |---|---|---|
 | `--name` | `dev` | cluster name |
 | `--workers` | `0` | worker count; control plane is untainted when 0 |
-| `--k8s-version` | `1.36` | Kubernetes minor, pinned digests for 1.32-1.36 (both distros) |
+| `--k8s-version` | distro latest | Kubernetes minor; kubeadm defaults to 1.37 (pins 1.32-1.37), k3s defaults to 1.36 (pins 1.32-1.36) |
 | `--distro` | `kubeadm` | `kubeadm` (kindest/node) or `k3s` (rancher/k3s: sqlite datastore, bundled local-path and metrics-server; kiac-lb handles LoadBalancers; `--cni` does not apply, kiac applies kindnet) |
 | `--image` | resolved from `--k8s-version` | explicit node image override |
 | `--cni` | `kindnet` | pod network: `kindnet`, `cilium` (requires `--kernel full` and the `cilium` CLI on your PATH), or `none` to bring your own |

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/saiyam1814/kiac/pkg/cluster"
@@ -27,6 +26,7 @@ var createClusterCmd = &cobra.Command{
   kiac create cluster --mount type=bind,source="$PWD",target=/workspace,readonly`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ui.Banner(Version)
+		selectedK8sVersion := k8sVersion
 		// Seed the typed family from the string flag (default ipv4) before
 		// Merge, so a config-file value can still override it when the flag
 		// was not set on the command line.
@@ -36,7 +36,7 @@ var createClusterCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			if err := fc.Merge(&createCfg, &k8sVersion, cmd.Flags().Changed); err != nil {
+			if err := fc.Merge(&createCfg, &selectedK8sVersion, cmd.Flags().Changed); err != nil {
 				return err
 			}
 		}
@@ -67,7 +67,10 @@ var createClusterCmd = &cobra.Command{
 		switch createDistro {
 		case "kubeadm":
 			if createCfg.Image == "" {
-				img, err := cluster.ResolveImage(k8sVersion)
+				if selectedK8sVersion == "" {
+					selectedK8sVersion = defaultK8sVersion(createDistro)
+				}
+				img, err := cluster.ResolveImage(selectedK8sVersion)
 				if err != nil {
 					return err
 				}
@@ -82,7 +85,10 @@ var createClusterCmd = &cobra.Command{
 				return fmt.Errorf("--cni applies to --distro kubeadm only; kiac installs kindnet on k3s")
 			}
 			if createCfg.Image == "" {
-				img, err := cluster.ResolveK3sImage(k8sVersion)
+				if selectedK8sVersion == "" {
+					selectedK8sVersion = defaultK8sVersion(createDistro)
+				}
+				img, err := cluster.ResolveK3sImage(selectedK8sVersion)
 				if err != nil {
 					return err
 				}
@@ -93,6 +99,13 @@ var createClusterCmd = &cobra.Command{
 			return fmt.Errorf("unknown --distro %q (supported: kubeadm, k3s)", createDistro)
 		}
 	},
+}
+
+func defaultK8sVersion(distro string) string {
+	if distro == "k3s" {
+		return cluster.DefaultK3sVersion
+	}
+	return cluster.DefaultK8sVersion
 }
 
 var (
@@ -108,8 +121,8 @@ func init() {
 	f.StringVar(&createConfigFile, "config", "", "cluster config YAML (see examples/cluster.yaml); flags set explicitly on the command line override file values")
 	f.StringVar(&createCfg.Name, "name", "dev", "cluster name")
 	f.IntVar(&createCfg.Workers, "workers", 0, "number of worker nodes (control plane is untainted when 0)")
-	f.StringVar(&k8sVersion, "k8s-version", cluster.DefaultK8sVersion,
-		"Kubernetes version ("+strings.Join(cluster.SupportedVersions(), ", ")+")")
+	f.StringVar(&k8sVersion, "k8s-version", "",
+		"Kubernetes version (default: latest pinned for the selected distro; kubeadm "+cluster.DefaultK8sVersion+", k3s "+cluster.DefaultK3sVersion+")")
 	f.StringVar(&createDistro, "distro", "kubeadm",
 		"Kubernetes distribution per node VM: kubeadm (kindest/node), or k3s (rancher/k3s: sqlite datastore, bundled local-path storage and metrics-server; kiac-lb handles LoadBalancers)")
 	f.StringVar(&createCfg.Image, "image", "", "node image (overrides --k8s-version)")

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/saiyam1814/kiac/pkg/cluster"
+)
+
+func TestDefaultK8sVersionUsesDistroReleaseStream(t *testing.T) {
+	if got := defaultK8sVersion("kubeadm"); got != cluster.DefaultK8sVersion {
+		t.Fatalf("kubeadm default = %q, want %q", got, cluster.DefaultK8sVersion)
+	}
+	if got := defaultK8sVersion("k3s"); got != cluster.DefaultK3sVersion {
+		t.Fatalf("k3s default = %q, want %q", got, cluster.DefaultK3sVersion)
+	}
+}

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -71,7 +71,7 @@ kiac create cluster --config cluster.yaml</code></pre>
     <tr><td><code>--config</code></td><td></td><td>cluster config YAML (see <a href="config-file.html">Config file</a>); flags set explicitly on the command line override file values</td></tr>
     <tr><td><code>--name</code></td><td><code>dev</code></td><td>cluster name (lowercase letters, digits, dashes)</td></tr>
     <tr><td><code>--workers</code></td><td><code>0</code></td><td>number of worker nodes (control plane is untainted when 0)</td></tr>
-    <tr><td><code>--k8s-version</code></td><td><code>1.36</code></td><td>Kubernetes version (1.36, 1.35, 1.34, 1.33, 1.32), for either distro</td></tr>
+    <tr><td><code>--k8s-version</code></td><td>distro latest</td><td>Kubernetes version: kubeadm defaults to 1.37 (1.32-1.37 pinned); k3s defaults to 1.36 (1.32-1.36 pinned). Versions 1.32 and 1.33 are retained for compatibility but are upstream end-of-life</td></tr>
     <tr><td><code>--distro</code></td><td><code>kubeadm</code></td><td>Kubernetes distribution per node VM: <code>kubeadm</code> (kindest/node), or <code>k3s</code> (rancher/k3s: sqlite datastore, bundled local-path storage and metrics-server; kiac-lb handles LoadBalancers). See <a href="k3s.html">k3s distro</a></td></tr>
     <tr><td><code>--image</code></td><td></td><td>node image (overrides <code>--k8s-version</code>)</td></tr>
     <tr><td><code>--cni</code></td><td><code>kindnet</code></td><td>pod network: <code>kindnet</code>, <code>cilium</code> (needs <code>--kernel full</code> and the <code>cilium</code> CLI), or <code>none</code> (bring your own). kubeadm distro only; the k3s path always gets kindnet</td></tr>

--- a/docs/docs/config-file.html
+++ b/docs/docs/config-file.html
@@ -63,8 +63,8 @@
   <p>This is <a href="https://github.com/saiyam1814/kiac/blob/main/examples/cluster.yaml">examples/cluster.yaml</a> from the repo; every key is optional:</p>
   <pre><code>name: dev            <span class="c"># cluster name: lowercase letters, digits, dashes</span>
 workers: 2           <span class="c"># worker node count; 0 untaints the control plane</span>
-k8sVersion: "1.36"   <span class="c"># Kubernetes minor ("1.36") or exact patch ("1.36.1")</span>
-<span class="c"># image: docker.io/kindest/node:v1.36.1   # node image, overrides k8sVersion</span>
+k8sVersion: "1.36"   <span class="c"># works with both distros; kubeadm also supports "1.37"</span>
+<span class="c"># image: docker.io/kindest/node:v1.36.4   # node image, overrides k8sVersion</span>
 cni: kindnet         <span class="c"># pod network: kindnet, or none to bring your own</span>
 <span class="c"># dns: [1.1.1.1, 8.8.8.8]  # node VM nameservers, up to 3; replaces the</span>
 <span class="c">#                    # runtime default resolv.conf entirely when set</span>
@@ -91,7 +91,7 @@ addons:
     <tr><th>Key</th><th>Type</th><th>Default</th><th>Maps to flag</th></tr>
     <tr><td><code>name</code></td><td>string</td><td><code>dev</code></td><td><code>--name</code></td></tr>
     <tr><td><code>workers</code></td><td>int</td><td><code>0</code></td><td><code>--workers</code></td></tr>
-    <tr><td><code>k8sVersion</code></td><td>string</td><td><code>"1.36"</code></td><td><code>--k8s-version</code></td></tr>
+    <tr><td><code>k8sVersion</code></td><td>string</td><td>distro latest: kubeadm <code>"1.37"</code>, k3s <code>"1.36"</code></td><td><code>--k8s-version</code></td></tr>
     <tr><td><code>image</code></td><td>string</td><td>resolved from <code>k8sVersion</code></td><td><code>--image</code></td></tr>
     <tr><td><code>cni</code></td><td>string</td><td><code>kindnet</code></td><td><code>--cni</code></td></tr>
     <tr><td><code>dns</code></td><td>list of IPs (max 3)</td><td>runtime default</td><td><code>--dns</code></td></tr>

--- a/docs/docs/dashboard.html
+++ b/docs/docs/dashboard.html
@@ -89,7 +89,7 @@ kubectl <span class="k">describe node kiac-dev-worker-1</span></code></pre>
   <h3>Kubeconfig download</h3>
   <p>Every card offers a standalone <code>kiac-&lt;name&gt;.kubeconfig</code> download, self-contained and pointed at the control plane's IP, handy for tools that want their own file instead of your merged <code>~/.kube/config</code>.</p>
   <h3>Create form</h3>
-  <p>The sidebar form covers the common knobs of <code>kiac create cluster</code>: name, workers, Kubernetes version (the pinned 1.32-1.36 list), CPUs and memory per node, CNI, and checkboxes for the kiac-lb LoadBalancer, metrics-server, local-path storage, observability, and Gateway API. Progress streams into an activity panel showing exactly the log the terminal would print. (<code>--distro</code> and <code>--kernel</code> are CLI-only knobs for now.)</p>
+  <p>The sidebar form covers the common knobs of <code>kiac create cluster</code>: name, workers, distro-specific pinned Kubernetes versions, CPUs and memory per node, CNI, and checkboxes for the kiac-lb LoadBalancer, metrics-server, local-path storage, observability, and Gateway API. Switching distro updates both the available versions and the default. Progress streams into an activity panel showing exactly the log the terminal would print. (<code>--kernel</code> is a CLI-only knob for now.)</p>
   <h3>Delete</h3>
   <p>Card-level delete, with a confirmation prompt, equivalent to <code>kiac delete cluster --name &lt;name&gt;</code>.</p>
 

--- a/docs/docs/getting-started.html
+++ b/docs/docs/getting-started.html
@@ -67,7 +67,7 @@
   <pre><code>kiac create cluster --name dev --workers 2</code></pre>
   <p>What happens, step by step:</p>
   <ol>
-    <li><b>Preflight checks</b>, then the pinned <code>kindest/node:v1.36.1</code> image is pulled.</li>
+    <li><b>Preflight checks</b>, then the pinned <code>kindest/node:v1.37.0</code> image is pulled.</li>
     <li><b>Three node VMs boot</b> in parallel (1 control plane + 2 workers), each with 4 vCPUs; the control plane gets 4G of memory and workers 2G by default (<code>--cpus</code>, <code>--cp-memory</code>, <code>--memory</code>).</li>
     <li><b>kubeadm</b> initializes the control plane and joins the workers concurrently.</li>
     <li><b>kindnet</b> (the CNI) is applied, then the default addons install: local-path storage and metrics-server in parallel, followed by the <b>kiac-lb</b> LoadBalancer (a tiny systemd service inside the control-plane VM).</li>
@@ -75,7 +75,7 @@
   </ol>
   <p>Useful variations:</p>
   <pre><code>kiac create cluster                          <span class="c"># single node named "dev", control plane untainted</span>
-kiac create cluster --k8s-version 1.34       <span class="c"># pick a Kubernetes minor (1.32-1.36 pinned)</span>
+kiac create cluster --k8s-version 1.34       <span class="c"># pick a Kubernetes minor (kubeadm 1.32-1.37 pinned)</span>
 kiac create cluster --distro k3s --workers 1 <span class="c"># k3s nodes, ready in under a minute; see k3s distro</span>
 kiac create cluster --cni cilium --kernel full <span class="c"># Cilium on the full kernel; see the Cilium page</span>
 kiac create cluster --observability --gateway <span class="c"># everything on; see the addon pages</span>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -105,7 +105,7 @@ git clone https://github.com/saiyam1814/kiac &amp;&amp; cd kiac &amp;&amp; make 
 kubectl top nodes    <span class="c"># native metrics, give it ~60s to scrape</span>
 kiac verify cluster --name dev</code></pre>
   <p><code>kiac verify cluster</code> is read-only and checks the complete path from each node VM and its services through Kubernetes readiness, DNS, storage, metrics, networking helpers, optional addons, and the Mac-to-API connection. Use <code>-o json</code> for a stable automation schema and a nonzero exit when a required check fails.</p>
-  <p>Supported Kubernetes versions are 1.32 through 1.36 (pinned image digests); 1.36 is the default. Pick one with <code>--k8s-version 1.34</code>, on either distro. In a hurry? <code>kiac create cluster --distro k3s --workers 1</code> is Ready in well under a minute.</p>
+  <p>Kubeadm supports Kubernetes 1.32 through 1.37 with 1.37 as its default; k3s supports 1.32 through 1.36 with 1.36 as its default. Every minor maps to a pinned image digest. Pick one with <code>--k8s-version 1.34</code>. Kubernetes 1.32 and 1.33 remain available for compatibility but are upstream end-of-life. In a hurry? <code>kiac create cluster --distro k3s --workers 1</code> is Ready in well under a minute.</p>
 
   <div class="note"><b>Where next?</b>
   <a href="getting-started.html">Getting started</a> walks through the whole flow including your first deploy. <a href="cli-reference.html">CLI reference</a> lists every command and flag.</div>

--- a/docs/docs/k3s.html
+++ b/docs/docs/k3s.html
@@ -61,7 +61,7 @@
 
   <h2 id="how">How it differs from the kubeadm path</h2>
   <p>The default distro boots <code>kindest/node</code> images (systemd, containerd, kubeadm) and initializes the cluster with <code>kubeadm init</code>/<code>join</code>. With <code>--distro k3s</code>, each VM boots a pinned <code>rancher/k3s</code> image and runs the k3s binary directly as PID 1: no systemd in the VM, no separate etcd, no kubeadm. The server keeps its state in sqlite, workers join as k3s agents over the standard <code>K3S_URL</code>/<code>K3S_TOKEN</code> mechanism, and the kubeconfig merges into <code>~/.kube/config</code> as <code>kiac-&lt;name&gt;</code>, exactly like the kubeadm path.</p>
-  <p>Kubernetes versions work the same way: minors 1.32 through 1.36 map to digest-pinned <code>rancher/k3s</code> images (1.36 default), selected with the same <code>--k8s-version</code> flag:</p>
+  <p>Kubernetes versions use the same flag but follow k3s's release stream: minors 1.32 through 1.36 map to digest-pinned <code>rancher/k3s</code> images (1.36 default). Kubeadm can move to a newer minor before k3s publishes its matching image:</p>
   <pre><code>kiac create cluster --distro k3s --k8s-version 1.34</code></pre>
 
   <h2 id="bundled">What k3s bundles, and what kiac does with it</h2>

--- a/docs/docs/networking.html
+++ b/docs/docs/networking.html
@@ -61,9 +61,9 @@
   <p>apple/container attaches each lightweight VM to macOS's <code>vmnet</code> network. Each node VM therefore gets its own IP address (typically in the <code>192.168.64.0/24</code> range) that is directly routable from your Mac:</p>
   <pre><code>kubectl get nodes -o wide
 <span class="o">NAME                     STATUS   ROLES           VERSION   INTERNAL-IP
-kiac-dev-control-plane   Ready    control-plane   v1.36.1   192.168.64.2
-kiac-dev-worker-1        Ready    &lt;none&gt;          v1.36.1   192.168.64.3
-kiac-dev-worker-2        Ready    &lt;none&gt;          v1.36.1   192.168.64.4</span></code></pre>
+kiac-dev-control-plane   Ready    control-plane   v1.37.0   192.168.64.2
+kiac-dev-worker-1        Ready    &lt;none&gt;          v1.37.0   192.168.64.3
+kiac-dev-worker-2        Ready    &lt;none&gt;          v1.37.0   192.168.64.4</span></code></pre>
   <p>Consequences:</p>
   <ul>
     <li>The API server is reached at <code>https://&lt;control-plane-ip&gt;:6443</code>; the kubeconfig points there directly.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -397,7 +397,7 @@
   <div class="grid">
     <div class="card"><h3>1 · Install the runtime</h3><p>Grab <a href="https://github.com/apple/container/releases" style="color:var(--accent);font-weight:600;text-decoration:none">apple/container 1.0</a> (signed pkg from Apple). Requires an Apple silicon Mac; macOS 26+ for multi-node.</p></div>
     <div class="card"><h3>2 · Install kiac</h3><p><code>brew install --cask saiyam1814/tap/kiac</code><br><br>Then check your setup: <code>kiac doctor</code></p></div>
-    <div class="card"><h3>3 · Create</h3><p><code>kiac create cluster --workers 2</code><br><br>Kubernetes 1.32-1.36, then <code>kubectl get nodes</code> and you are flying.</p></div>
+    <div class="card"><h3>3 · Create</h3><p><code>kiac create cluster --workers 2</code><br><br>Kubernetes 1.32-1.37, then <code>kubectl get nodes</code> and you are flying.</p></div>
   </div>
   <p style="margin-top:26px;color:var(--mid)">From there the <a href="docs/index.html" style="color:var(--accent);font-weight:600;text-decoration:none">documentation</a> covers networking, the k3s distro, Cilium and custom kernels, reboots and resume, observability, Gateway API, node chaos, the dashboard, and every CLI flag.</p>
 </section>
@@ -412,7 +412,7 @@ const lines = [
   ['', '<span class="d">$</span> <span class="b">kiac create cluster --name dev --workers 2</span>'],
   [400, '<span class="o">⬢ kiac</span> <span class="d">· Kubernetes in Apple Containers</span>'],
   [600, ' <span class="ok">✓</span> Preflight checks <span class="d">(0.3s)</span>'],
-  [900, ' <span class="ok">✓</span> Pulling node image kindest/node:v1.36.1 <span class="d">(4.6s)</span>'],
+  [900, ' <span class="ok">✓</span> Pulling node image kindest/node:v1.37.0 <span class="d">(4.6s)</span>'],
   [1500, ' <span class="ok">✓</span> Booting 3 node VM(s) <span class="d">(6.8s)</span>'],
   [2600, ' <span class="ok">✓</span> Initializing Kubernetes control plane <span class="d">(24.3s)</span>'],
   [3200, ' <span class="ok">✓</span> Joining 2 worker(s) <span class="d">(9.1s)</span>'],

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -19,14 +19,15 @@ name: full
 # workers the control plane is untainted and runs your pods. Default: 0.
 workers: 3
 
-# Kubernetes version: a supported minor ("1.32" through "1.36") or an
-# exact patch ("1.36.1"). Each minor is pinned to a tested
-# kindest/node image digest. Default: "1.36".
+# Kubernetes version: a supported minor ("1.32" through "1.37") or an
+# exact patch. Each minor is pinned to a tested image digest. This
+# cross-distro example uses "1.36"; kubeadm defaults to "1.37" while
+# k3s currently defaults to "1.36".
 k8sVersion: "1.36"
 
 # Node image, overrides k8sVersion entirely. Leave unset unless you
 # need a specific kindest/node build.
-# image: docker.io/kindest/node:v1.36.1
+# image: docker.io/kindest/node:v1.36.4
 
 # Pod network: kindnet (the default), or none to bring your own CNI.
 # The stock node kernel has no VXLAN/br_netfilter/BPF-JIT modules, so

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -7,8 +7,8 @@
 
 name: dev            # cluster name: lowercase letters, digits, dashes
 workers: 2           # worker node count; 0 untaints the control plane
-k8sVersion: "1.36"   # Kubernetes minor ("1.36") or exact patch ("1.36.1")
-# image: docker.io/kindest/node:v1.36.1   # node image, overrides k8sVersion
+k8sVersion: "1.36"   # works with both distros; kubeadm also supports "1.37"
+# image: docker.io/kindest/node:v1.36.4   # node image, overrides k8sVersion
 cni: kindnet         # pod network: kindnet, or none to bring your own
 ipFamily: ipv4       # ipv4 (default), dual (IPv4-primary + IPv6), or ipv6 (IPv6-primary).
                      # dual/ipv6 auto-select the full kernel (IPv6 netfilter) and need macOS 26+.

--- a/pkg/cluster/k3s_test.go
+++ b/pkg/cluster/k3s_test.go
@@ -14,10 +14,10 @@ func TestResolveK3sImage(t *testing.T) {
 		want    string // substring of resolved image
 		wantErr bool
 	}{
-		{in: "1.36", want: "rancher/k3s:v1.36.2-k3s1@sha256:"},
-		{in: "v1.36", want: "rancher/k3s:v1.36.2-k3s1@sha256:"},
+		{in: "1.36", want: "rancher/k3s:v1.36.4-k3s1@sha256:"},
+		{in: "v1.36", want: "rancher/k3s:v1.36.4-k3s1@sha256:"},
 		{in: "1.32", want: "rancher/k3s:v1.32.13-k3s1@sha256:"},
-		{in: "1.34.9", want: "rancher/k3s:v1.34.9-k3s1@sha256:"},
+		{in: "1.34.11", want: "rancher/k3s:v1.34.11-k3s1@sha256:"},
 		{in: "1.34.2", want: "rancher/k3s:v1.34.2-k3s1"}, // unpinned patch fallback
 		{in: "1.19", wantErr: true},
 		{in: "latest", wantErr: true},
@@ -38,8 +38,8 @@ func TestResolveK3sImage(t *testing.T) {
 			t.Errorf("ResolveK3sImage(%q) = %q, want substring %q", c.in, got, c.want)
 		}
 	}
-	if def := SupportedK3sVersions()[0]; def != DefaultK8sVersion {
-		t.Errorf("newest k3s-supported version %q should equal default %q", def, DefaultK8sVersion)
+	if def := SupportedK3sVersions()[0]; def != DefaultK3sVersion {
+		t.Errorf("newest k3s-supported version %q should equal default %q", def, DefaultK3sVersion)
 	}
 }
 

--- a/pkg/cluster/versions.go
+++ b/pkg/cluster/versions.go
@@ -12,23 +12,27 @@ import (
 var nodeImages = map[string]string{
 	"1.32": "docker.io/kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8",
 	"1.33": "docker.io/kindest/node:v1.33.12@sha256:3f5c8443c620245e4d355cfe09e96a91ead32ceaa569d3f1ca9edf0cb2fe2ff4",
-	"1.34": "docker.io/kindest/node:v1.34.8@sha256:02722c2dedddcfc00febf5d27fbeb9b7b2c14294c82109ff4a85d89ac9ba3256",
-	"1.35": "docker.io/kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95",
-	"1.36": "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+	"1.34": "docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d",
+	"1.35": "docker.io/kindest/node:v1.35.8@sha256:07b2536e30b803ed61d1677a79df6115f798ce64c80f9e22f6ed45afd09323c0",
+	"1.36": "docker.io/kindest/node:v1.36.4@sha256:099e049362a1526b2db71494e1947aae99bd16290d7c895f2b7ea312e3cbfaed",
+	"1.37": "docker.io/kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5",
 }
 
-// DefaultK8sVersion is the minor used when neither --k8s-version nor
-// --image is given.
-const DefaultK8sVersion = "1.36"
+// Defaults are distro-specific because upstream Kubernetes and k3s do
+// not publish new minors at the same time.
+const (
+	DefaultK8sVersion = "1.37"
+	DefaultK3sVersion = "1.36"
+)
 
-// ResolveImage maps a Kubernetes version like "1.36", "v1.36" or
-// "1.36.1" to a pinned node image. Full patch versions outside the pin
+// ResolveImage maps a Kubernetes version like "1.37", "v1.37" or
+// "1.37.0" to a pinned node image. Full patch versions outside the pin
 // table fall back to the matching kindest/node tag, unpinned.
 func ResolveImage(version string) (string, error) {
 	v := strings.TrimPrefix(strings.TrimSpace(version), "v")
 	parts := strings.Split(v, ".")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("invalid Kubernetes version %q (want e.g. 1.36)", version)
+		return "", fmt.Errorf("invalid Kubernetes version %q (want e.g. %s)", version, DefaultK8sVersion)
 	}
 	minor := parts[0] + "." + parts[1]
 	if img, ok := nodeImages[minor]; ok && len(parts) == 2 {
@@ -60,9 +64,9 @@ func SupportedVersions() []string {
 var k3sImages = map[string]string{
 	"1.32": "docker.io/rancher/k3s:v1.32.13-k3s1@sha256:7534b63e02277917f77c584ed5532b31562c760d6bb8fe88059002e9bdeee033",
 	"1.33": "docker.io/rancher/k3s:v1.33.13-k3s1@sha256:523cfdf26aaef2c3164eefa30a61f5f1dca86d1cf3f1d38beae62ac65905a3ab",
-	"1.34": "docker.io/rancher/k3s:v1.34.9-k3s1@sha256:9c162556657a38e394d1f944081388ae7c0b85ec29134c509583083e287f804e",
-	"1.35": "docker.io/rancher/k3s:v1.35.6-k3s1@sha256:9d6b9c15e8031c1aea7dd7f0cdc019f5e74a23c53b9eada564b7a8dc94efc14c",
-	"1.36": "docker.io/rancher/k3s:v1.36.2-k3s1@sha256:6a47cea22c4b834d4ba72c89d291696b79ebe406251f90b446e4dff03513dd87",
+	"1.34": "docker.io/rancher/k3s:v1.34.11-k3s1@sha256:5d52389a0f4fd7ebdb5a1fb2d7c67c35da966230782c4abb0667d86bcccea9c2",
+	"1.35": "docker.io/rancher/k3s:v1.35.8-k3s1@sha256:59fe491fd3b73204e499e40b325240d85c42c7189c3ae50150d37b78243f3b32",
+	"1.36": "docker.io/rancher/k3s:v1.36.4-k3s1@sha256:edad48e12bf81c3a09ac1c05c0c0ffaaa22145980b989d6fae84543a76b83657",
 }
 
 // ResolveK3sImage maps a Kubernetes version to a pinned rancher/k3s
@@ -72,7 +76,7 @@ func ResolveK3sImage(version string) (string, error) {
 	v := strings.TrimPrefix(strings.TrimSpace(version), "v")
 	parts := strings.Split(v, ".")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("invalid Kubernetes version %q (want e.g. %s)", version, DefaultK8sVersion)
+		return "", fmt.Errorf("invalid Kubernetes version %q (want e.g. %s)", version, DefaultK3sVersion)
 	}
 	minor := parts[0] + "." + parts[1]
 	if img, ok := k3sImages[minor]; ok && len(parts) == 2 {

--- a/pkg/cluster/versions_test.go
+++ b/pkg/cluster/versions_test.go
@@ -11,10 +11,10 @@ func TestResolveImage(t *testing.T) {
 		want    string // substring of resolved image
 		wantErr bool
 	}{
-		{in: "1.36", want: "kindest/node:v1.36.1@sha256:"},
-		{in: "v1.36", want: "kindest/node:v1.36.1@sha256:"},
+		{in: "1.37", want: "kindest/node:v1.37.0@sha256:"},
+		{in: "v1.36", want: "kindest/node:v1.36.4@sha256:"},
 		{in: "1.32", want: "kindest/node:v1.32.11@sha256:"},
-		{in: "1.34.8", want: "kindest/node:v1.34.8@sha256:"},
+		{in: "1.34.11", want: "kindest/node:v1.34.11@sha256:"},
 		{in: "1.34.2", want: "kindest/node:v1.34.2"}, // unpinned patch fallback
 		{in: "1.19", wantErr: true},
 		{in: "latest", wantErr: true},

--- a/pkg/webui/index.html
+++ b/pkg/webui/index.html
@@ -183,9 +183,16 @@ const state = { clusters: [], metrics: {}, addons: {} };
 
 async function loadMeta() {
   const m = await j('/api/meta');
-  $('version').innerHTML = m.versions.map(v => `<option ${v===m.defaultVersion?'selected':''}>${esc(v)}</option>`).join('');
   $('cni').innerHTML = m.cnis.map(c => `<option>${esc(c)}</option>`).join('');
   $('distro').innerHTML = (m.distros || ['kubeadm']).map(d => `<option>${esc(d)}</option>`).join('');
+  const syncVersions = (useDefault = false) => {
+    const k3s = $('distro').value === 'k3s';
+    const versions = k3s ? (m.k3sVersions || m.versions) : m.versions;
+    const fallback = k3s ? (m.defaultK3sVersion || m.defaultVersion) : m.defaultVersion;
+    const current = $('version').value;
+    $('version').innerHTML = versions.map(v => `<option>${esc(v)}</option>`).join('');
+    $('version').value = !useDefault && versions.includes(current) ? current : fallback;
+  };
   const syncForm = () => {
     const k3s = $('distro').value === 'k3s';
     const cil = !k3s && $('cni').value === 'cilium';
@@ -195,8 +202,9 @@ async function loadMeta() {
     else if (cil) { note.textContent = 'Cilium downloads the full node kernel once (~40MB) and needs the cilium CLI: brew install cilium-cli.'; note.style.display = 'block'; }
     else { note.style.display = 'none'; }
   };
-  $('distro').addEventListener('change', syncForm);
+  $('distro').addEventListener('change', () => { syncVersions(true); syncForm(); });
   $('cni').addEventListener('change', syncForm);
+  syncVersions();
   syncForm();
 }
 

--- a/pkg/webui/webui.go
+++ b/pkg/webui/webui.go
@@ -137,10 +137,12 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 
 func (s *server) meta(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, map[string]any{
-		"versions":       cluster.SupportedVersions(),
-		"defaultVersion": cluster.DefaultK8sVersion,
-		"cnis":           []string{"kindnet", "cilium", "none"},
-		"distros":        []string{"kubeadm", "k3s"},
+		"versions":          cluster.SupportedVersions(),
+		"defaultVersion":    cluster.DefaultK8sVersion,
+		"k3sVersions":       cluster.SupportedK3sVersions(),
+		"defaultK3sVersion": cluster.DefaultK3sVersion,
+		"cnis":              []string{"kindnet", "cilium", "none"},
+		"distros":           []string{"kubeadm", "k3s"},
 	})
 }
 

--- a/pkg/webui/webui_test.go
+++ b/pkg/webui/webui_test.go
@@ -86,6 +86,31 @@ func TestServeGuardsAllRoutes(t *testing.T) {
 	}
 }
 
+func TestMetaHasDistroSpecificVersionDefaults(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://localhost/api/meta", nil)
+	rec := httptest.NewRecorder()
+	(&server{}).meta(rec, req)
+
+	var got struct {
+		Versions          []string `json:"versions"`
+		DefaultVersion    string   `json:"defaultVersion"`
+		K3sVersions       []string `json:"k3sVersions"`
+		DefaultK3sVersion string   `json:"defaultK3sVersion"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Versions) == 0 || got.Versions[0] != got.DefaultVersion {
+		t.Fatalf("kubeadm versions/default = %v/%q", got.Versions, got.DefaultVersion)
+	}
+	if len(got.K3sVersions) == 0 || got.K3sVersions[0] != got.DefaultK3sVersion {
+		t.Fatalf("k3s versions/default = %v/%q", got.K3sVersions, got.DefaultK3sVersion)
+	}
+	if got.DefaultVersion == got.DefaultK3sVersion {
+		t.Fatalf("expected distro defaults to differ while k3s 1.37 is unavailable; both are %q", got.DefaultVersion)
+	}
+}
+
 func TestParseTopNodes(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Closes #45.

## What changed

- add the digest-pinned `kindest/node:v1.37.0` image and refresh supported active minors to their latest patch releases
- keep the k3s default on its newest published line, `v1.36.4-k3s1`, until upstream publishes 1.37
- select defaults per distro in the CLI and web UI while preserving explicit `--k8s-version` and config values
- update the version matrix, examples, website, and tests

## Why

Kubernetes 1.37 is available in `kindest/node`, but no `rancher/k3s:v1.37.0-k3s1` image exists yet. A shared default would either hold kubeadm back or break default k3s creation. Distro-specific defaults let each integration follow its upstream release stream.

## Verification

- `env GOTOOLCHAIN=go1.25.12 make ci`
- real Apple-container kubeadm cluster: Kubernetes 1.37.0, 1 control plane + 3 workers
- real Apple-container k3s cluster: Kubernetes 1.36.4+k3s1, 1 server + 3 agents
- both runtime runs passed node readiness, metrics, default storage, host bind mounts, Gateway API/HTTPRoute traffic, Prometheus/Grafana, LoadBalancer assignment, authenticated edge-proxy checks, 1 MiB cross-node upload with SHA-256 validation, and node recovery
- k3s additionally passed a full four-VM stop/resume with fresh addresses and repeated workload, mount, Gateway, observability, and upload checks
