### PR TITLE
feat: add mock GPU scheduling alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Containers are great for packaging software, and kiac depends on them. The point
 - 📈 **Observability built in** — `--observability` installs Prometheus and Grafana on a real LoadBalancer IP, with Cluster Overview and Nodes dashboards already provisioned.
 - 🌍 **IPv6 and dual-stack** — `--ip-family dual` (or `ipv6`) gives pods, Services, and nodes real IPv6, with kube-proxy programming IPv6 ClusterIP/NodePort/LoadBalancer rules on the full kernel. kiac-lb hands out both families, the edge proxy fixes v6 large uploads too, and `kiac resume` heals both. See [docs/design/ipv6-dual-stack.md](docs/design/ipv6-dual-stack.md).
 - 🚪 **Gateway API built in** — `--gateway` installs the Gateway API CRDs and Traefik with a ready-to-use GatewayClass and Gateway, so an HTTPRoute works out of the box.
+- **GPU scheduling alpha** — `--gpu-mock` installs a tiny, opt-in device plugin and the `kiac-gpu` RuntimeClass so GPU-shaped charts can be tested today. It is explicitly a scheduling mock and provides no Apple GPU acceleration yet.
 - 💥 **Node chaos you can trust** — `kiac stop node` / `kiac start node` stop and restart a real node VM: NotReady detection, eviction, rescheduling, rejoin.
 - **Diagnostics with an exit code** — `kiac verify cluster` checks the VM, Kubernetes, DNS, storage, metrics, edge proxy, LoadBalancer, Gateway, observability, and host API paths without changing the cluster. JSON output is stable for automation; `kiac support bundle` writes a bounded, redacted archive for issue reports.
 - 📄 **Declarative clusters** — `kiac create cluster --config cluster.yaml` describes the whole cluster in one file; explicit flags override it.
@@ -177,6 +178,15 @@ kiac create cluster --name dev --workers 2 --observability --gateway
 
 One command later you have Grafana at port 3000 on a real LoadBalancer IP (anonymous admin, local-only, two dashboards already provisioned) and a Gateway serving HTTP on port 80, also on a LoadBalancer IP. Point an HTTPRoute at `parentRefs: [{name: kiac, namespace: kiac-gateway}]` and it routes with zero extra setup; see [`examples/gateway-api-lab.md`](examples/gateway-api-lab.md), [`examples/observability-lab.md`](examples/observability-lab.md), and [`examples/httproute.yaml`](examples/httproute.yaml). The same two flags work on kubeadm, k3s, and Cilium clusters.
 
+### Test GPU-shaped workloads (alpha)
+
+```bash
+kiac create cluster --name gpu-lab --workers 2 --gpu-mock
+kubectl apply -f examples/gpu-mock.yaml
+```
+
+This opt-in mode advertises one synthetic `kiac.dev/gpu` per node and installs a pass-through `kiac-gpu` RuntimeClass. The kiac-specific name avoids colliding with distro- or vendor-owned runtime handlers such as k3s's immutable `nvidia` RuntimeClass. It validates Kubernetes scheduling and chart assumptions only: it does **not** expose the Apple GPU, CUDA, Metal, or Vulkan acceleration. See [`examples/gpu-mock-lab.md`](examples/gpu-mock-lab.md) and the [GPU build plan](docs/design/gpu-build-plan.md).
+
 ### Run Portainer CE on kiac
 
 This example installs Portainer Community Edition as an optional application inside a kiac Kubernetes cluster. Portainer is not bundled with kiac and adds nothing to normal cluster startup or idle resource use. Community Edition does not require a license key; Portainer Business Edition does.
@@ -237,6 +247,7 @@ kiac create cluster --distro k3s --workers 1 # rancher/k3s nodes: sqlite datasto
 kiac create cluster --cni cilium --kernel full --workers 2   # Cilium eBPF on the full node kernel
 kiac create cluster --config cluster.yaml    # declarative; explicit flags override the file (see examples/cluster.yaml)
 kiac create cluster --mount type=bind,source="$PWD",target=/workspace,readonly # host directory in every node
+kiac create cluster --gpu-mock              # alpha scheduling contract only; no GPU acceleration
 kiac ui                                      # local web console: manage clusters, kubectl Console per cluster
 kiac get clusters                            # -o wide for versions/age, -o json for scripts
 kiac get nodes --name dev
@@ -279,6 +290,7 @@ Full guides and command reference live on the [docs site](https://saiyam1814.git
 | `--no-edge-proxy` | `false` | skip the node-local edge proxy that fixes large TCP uploads through NodePorts and LoadBalancers |
 | `--observability` | `false` | install Prometheus + Grafana + node-exporter, Grafana on a LoadBalancer IP |
 | `--gateway` | `false` | install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway |
+| `--gpu-mock` | `false` | advertise one synthetic `kiac.dev/gpu` per node and install RuntimeClass `kiac-gpu` for scheduling tests; no hardware acceleration |
 | `--config` | | cluster config YAML (see [`examples/cluster.yaml`](examples/cluster.yaml)); flags set explicitly on the command line override file values (`--distro` and `--kernel` are flags only for now) |
 | `--wait` | `5m` | timeout for each readiness step, including CNI installation |
 
@@ -298,6 +310,7 @@ Host bind mounts use ordinary `container run`, not `container machine`; `/Users`
 - **HA control planes**
 - **One-flag Calico and Flannel** on the full kernel
 - **Hubble UI** for Cilium clusters
+- **Apple GPU worker nodes** through krunkit/Venus, gated by the published validation spike in [`docs/design/gpu-build-plan.md`](docs/design/gpu-build-plan.md)
 
 ## Contributing
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -140,6 +140,7 @@ func init() {
 	f.BoolVar(&createCfg.NoEdgeProxy, "no-edge-proxy", false, "skip the node-local edge proxy that fixes large TCP uploads through NodePorts and LoadBalancers")
 	f.BoolVar(&createCfg.Observability, "observability", false, "install Prometheus + Grafana + node-exporter, Grafana on a LoadBalancer IP")
 	f.BoolVar(&createCfg.Gateway, "gateway", false, "install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway")
+	f.BoolVar(&createCfg.GPUMock, "gpu-mock", false, "advertise one mock kiac.dev/gpu resource per node for scheduling tests (no GPU acceleration)")
 	f.DurationVar(&createCfg.WaitTimeout, "wait", 5*time.Minute, "timeout for each cluster readiness step, including CNI installation")
 	createCmd.AddCommand(createClusterCmd)
 }

--- a/docs/design/gpu-build-plan.md
+++ b/docs/design/gpu-build-plan.md
@@ -1,0 +1,420 @@
+# kiac GPU build plan (blueprint v3 → code)
+
+Agent-ready engineering plan for "Apple GPU as a first-class Kubernetes device."
+Self-contained: everything you need is in this file plus the referenced kiac code.
+Derived from blueprint v3 (12-agent research synthesis, 2026-09-03) and a 4-agent
+code recon of this repo (2026-09-04). When this plan and the code disagree, the
+code wins — re-verify line numbers before editing; they drift.
+
+## 0. Mission and non-goals
+
+Ship, in order: a mock GPU resource on today's clusters (P1), krunkit-backed GPU
+node VMs joined to the same cluster (P2), a schedulable `kiac.dev/gpu` device with
+GFD-shaped labels (P3), an nvidia.com/gpu compat bridge (P4), the first DRA driver
+for an Apple GPU (P5), then APIR pools / standalone stack / multi-Mac (P6-P8).
+
+Hard non-goals (never build, never imply):
+- No CUDA/NVML emulation. nvidia-smi, torch.cuda, DCGM never work. CUDA images
+  never run; docs carry the Vulkan image swap table instead.
+- No node ever advertises `nvidia.com/gpu` in capacity. The compat bridge is a
+  per-pod admission rewrite with an audit annotation.
+- No MLX or Metal API inside pods; no in-cluster tensor parallelism (TB5 RDMA is
+  host-native); no macOS nodes (no macOS kubelet exists).
+- No per-pod GPU compute throttling on private APIs (no public per-process Metal
+  priority exists). Enforcement claims are limited to what the VM memory window
+  actually enforces.
+- Not competing on raw speed. Host-native Ollama/MLX is faster and we say so;
+  `kiac gpu bench` prints the honest numbers.
+- APIR (P6) is never multitenant: single-tenant taint, always.
+
+## 1. Verified facts you must not re-litigate (Sept 2026)
+
+- apple/container will never expose the GPU (containerization#46 wontfix). GPU
+  nodes REQUIRE a second VM backend: krunkit (libkrun, Hypervisor.framework,
+  virtio-gpu + Venus → virglrenderer → MoltenVK → Metal), ~75-80% of native.
+- Prior art: minikube v1.37.0 ships an official krunkit driver + "AI playground"
+  tutorial (K8s inside a krunkit VM, pods share /dev/dri via
+  squat/generic-device-plugin, resource `devic.es/dri`). Single node, no DRA, no
+  memory accounting. That is the bar to beat, and proof the pattern works.
+- Modern guest userspace breaks on a 16KiB blob-alignment bug (krunkit#114), NOT
+  ABI drift; fix must land in Mesa (VIRTIO_GPU_F_BLOB_ALIGNMENT). Pin workload
+  images to Mesa 25.0.x-era userspace (Fedora 42 class; quay.io/ramalama works).
+- Per-VM RAM+vRAM addressable is ~62GiB (36-bit IPA); krunkit auto-sizes the GPU
+  shm window as (62GiB - guest RAM). libkrun PR #765 (40-bit) lifts this later.
+  `krun_set_gpu_options2(shm_size)` is the per-VM hard vRAM cap primitive.
+- APIR (near-native llama.cpp): guest side merged upstream (GGML_VIRTGPU,
+  llama.cpp, 2026-01-28); virglrenderer !1590 + libkrun #508 unmerged — shipping
+  APIR means carrying those two patches. APIR disables Venus in that VM and is
+  not multitenant safe. Different container image (GGML_VIRTGPU build), never
+  "same YAML".
+- K8s 1.37: DRA extended-resource mapping is STABLE
+  (`DeviceClass.spec.extendedResourceName`). DRA consumable capacity: on by
+  default 1.36+, feature-gate flip on 1.34-1.35.
+- Resource-name plurality is normal in production (nvidia.com/gpu, gpu.shared,
+  mig-1g.5gb, HAMi gpumem/gpucores; autoscaler#8095). Charts parameterize the
+  name (vLLM production-stack `requestGPUType`, KServe
+  `serving.kserve.io/gpu-resource-types`, Ollama chart raw resources).
+
+## 2. Contracts (fixed now; changing any of these later is a breaking change)
+
+- Alpha resource name: `kiac.dev/gpu` — define once as `const gpuResourceDomain =
+  "kiac.dev"` / `const gpuResourceName = "kiac.dev/gpu"` in pkg/cluster/gpu.go.
+  `kiac.dev` did not resolve in DNS on 2026-09-04, so this is explicitly an
+  unstable alpha contract. Confirm control of the final domain before P3; keep
+  it a single const so that pre-stable rename remains one line.
+- Node labels (GFD-shaped, on GPU + mock nodes):
+  `kiac.dev/gpu.present=true`, `kiac.dev/gpu.product` ("Apple M-series (Venus)"
+  or "Mock"), `kiac.dev/gpu.memory` (MiB, the VM window), `kiac.dev/gpu.count`,
+  `kiac.dev/gpu.api` (venus|apir|mock).
+- GPU node naming: `kiac-<cluster>-gpu-<n>` (new suffix class; see P2 grammar
+  checklist). Taint on GPU nodes: `kiac.dev/gpu=true:NoSchedule`. APIR nodes add
+  `kiac.dev/gpu-apir=true:NoSchedule` (single-tenant enforced by a
+  one-workload-per-node admission rule in P6, not by count).
+- RuntimeClass: install a pass-through `kiac-gpu` RuntimeClass with handler
+  `runc` so GPU-shaped manifests can select the alpha explicitly. Do not create
+  or replace `nvidia`: k3s already owns that immutable RuntimeClass with handler
+  `nvidia`, and changing it breaks installation while impersonating a runtime
+  that kiac does not provide. The Kubernetes API requires a non-empty handler;
+  verify `runc` on both kindest/node and k3s.
+- Compat rewrite annotation: `kiac.dev/rewrote-gpu-resource: "nvidia.com/gpu"`.
+- Verify check IDs (SchemaVersion 1 stays 1; append-only):
+  `gpu.runtime-class`, `gpu.device-plugin`, `gpu.nodes`, `gpu.node.<name>`. MUST
+  report Skip (never Fail) on clusters without the feature — see
+  pkg/cluster/verify.go:59 contract comment (verify.go:35).
+- Version pins (record in code tables per repo convention, never inline):
+  krunkit >= 1.3.2 (`brew tap slp/krun`, then `brew install krunkit`; the old
+  `slp/krunkit` tap is deprecated),
+  vmnet-helper (minikube-documented release), workload demo image
+  quay.io/ramalama pinned to an exact tag+digest at implementation time,
+  generic-device-plugin pinned by digest, K8s default 1.37 (already
+  DefaultK8sVersion in pkg/cluster/versions.go).
+
+## 3. Repo strategy
+
+- kiac repo (this one): backend, CLI, embedded manifests, docs. Everything in
+  P0-P2 and the kiac halves of P3-P5.
+- NEW repo `macgpu` (create at P3 start): the standalone stack — Helm chart
+  (device-plugin config, labeler, compat webhook, later DRA driver), component
+  images, `macgpu-node` join binary (P8). kiac EMBEDS rendered, pinned manifests
+  of macgpu components exactly the way it embeds Traefik/Gateway upstream
+  manifests today (pkg/cluster/gateway_assets.go pattern: one //go:embed var per
+  file, doc comment with upstream source + version + rationale).
+- Until P3, no new repo: mock mode uses upstream squat/generic-device-plugin.
+
+## 4. Working agreements (repo conventions — recon-verified; follow exactly)
+
+- cobra RunE stays a thin shim; ALL orchestration in pkg/cluster (cmd/root.go:1).
+  New command files self-register via init() + rootCmd.AddCommand (cmd/node.go
+  pattern). Add cmd/gpu.go with `gpuCmd` parent (Use+Short only) and leaves.
+- Every user-visible phase wraps in ui.Step(title, fn); details ui.Infof;
+  copy-paste follow-ups ui.Hintf; doctor-style lines ui.Check (pkg/ui/ui.go).
+- Errors: lowercase fmt.Errorf, %w for causes, exact remedial command inline
+  ("install it with: brew install krunkit").
+- Addons: optional ones degrade (ui.Infof + continue) after labelLBPrimary,
+  gated on cfg.CNI != "none" — cluster.go:418-430 and the k3s twin
+  k3s.go:376-386. EVERY addon ships kubeadm and k3s twins.
+- Embedded assets: pkg/cluster/assets/gpu/*.yaml + pkg/cluster/gpu_assets.go;
+  every image pinned to exact tag (+digest where the pattern does); validated in
+  gpu_test.go by the decodeAll + pinned-image-regex pattern (gateway_test.go).
+- Config plumbing triple: Config field (cluster.go:106-125) + flag in
+  cmd/create.go init() + configfile.go Merge guarded by the EXACT flag-name
+  string (KnownFields(true): missing YAML keys = parse failure for users).
+- Tests hermetic, table-driven, no mock frameworks: fake backend binaries as
+  shell scripts in t.TempDir injected via runtime.Client{Bin: script}
+  (verify_test.go:95-136). CI = `make ci` on macos-26, Go 1.25.12; hosted
+  runners have NO krunkit and NO GPU — real GPU coverage goes to the
+  self-hosted runtime-smoke workflow as a new profile.
+- Downloaded artifacts: URL+sha256 tables, ~/.kiac/ cache, digest re-verified on
+  every cache hit (kernel.go kernelAssets + downloadVerified — reuse it).
+- Comments explain WHY at mechanism level, citing issues (repo standard).
+
+---
+
+## P0 — Validation spike (1-2 weeks, NO kiac code, do first, publish results)
+
+Nobody has published two concurrent krunkit GPU VMs on one Mac. This decides P2+.
+
+Protocol (scripts + results land in test/spike-gpu/, a README with numbers):
+1. Install krunkit + vmnet-helper (record exact versions; brew or source).
+2. Boot ONE krunkit VM from a Fedora 42 cloud image (cloud-init NoCloud seed for
+   SSH key). Verify /dev/dri exists; `vulkaninfo` inside a podman/docker
+   container in the guest using a Mesa-25.0.x-era image shows
+   "Virtio-GPU Venus (Apple ...)".
+3. Baseline: host-native `llama-bench` (llama.cpp Metal) on a pinned model
+   (qwen3-4b-q4_k_m.gguf or similar). Record tok/s pp+tg.
+4. In-VM: same model, llama.cpp Vulkan build, `-ngl 999`. Record tok/s and the
+   %-of-native. Expect 75-80%; if far below, STOP and investigate before P2.
+5. TWO VMs concurrently: run llama-bench in both simultaneously. Record: does
+   macOS time-slice (both make progress)? aggregate vs solo throughput? any
+   crash/starvation?
+6. vRAM window: verify the (62GiB - guest RAM) auto-sizing; if krunkit exposes
+   no flag, confirm via guest /sys or allocation failure point. Attempt the
+   ~10-line krunkit patch exposing shm_size; verify a 8GiB-window VM fails
+   allocations past 8GiB while a 32GiB one succeeds.
+7. Kubelet probe: install k3s agent OR kubeadm+containerd in the guest; join a
+   throwaway kiac cluster manually (token from cp). Confirm Ready node +
+   /dev/dri visible to a privileged pod.
+Acceptance: README with the five numbers (native, venus solo, venus x2, window
+cap behavior, join success), versions table, and every command reproducible.
+Publish (blog/gist) — it's a first.
+
+Current execution note (2026-09-04): the available host is an M1 Max MacBook
+Pro with 32 GPU cores and 64 GiB unified memory, but had only 4.2 GiB free disk
+and no krunkit installation. Do not begin the image-heavy spike until at least
+30 GiB is available. The hardware is suitable; storage is the blocker.
+
+## P1 — Mock GPU mode on today's kiac (independent of P0; parallelizable)
+
+Goal: `kiac create cluster --gpu-mock` → charts requesting `kiac.dev/gpu`
+schedule on stock apple/container nodes; labels + RuntimeClass appear; works on
+kubeadm AND k3s; CI-testable on hosted runners.
+
+Tasks:
+1. Config: add `GPUMock bool` to cluster.Config (cluster.go:106-125). Flag
+   `--gpu-mock` in cmd/create.go init() (pattern of --observability line ~141).
+   configfile.go: extend FileAddons with `GPUMock *bool yaml:"gpuMock"`, Merge
+   guarded by changed("gpu-mock"). Zero value = today's behavior.
+2. Assets: pkg/cluster/assets/gpu/{namespace,device-plugin,runtimeclass}.yaml.
+   device-plugin.yaml = squat/generic-device-plugin 0.2.0, pinned to multi-arch
+   digest `sha256:66c8d5c270eb2b721f1064c549b9b7898152a6d2f0163380a5d37dc7636c20ff`
+   (verified to contain linux/arm64), `--domain kiac.dev`, device `gpu`, count 1.
+   The plugin cannot advertise a count without discovering a path. Use
+   `/dev/null` as the harmless mock marker; allocation mounts it at
+   `/dev/kiac-mock-gpu` and provides no acceleration.
+   Never use an optional missing path: upstream discovery then advertises zero.
+3. pkg/cluster/gpu.go: `installGPU(cp string, cfg Config) error` +
+   `installGPUK3s` twin, in the installGateway shape (gateway.go:19): ui.Step
+   per phase, m.rt.ExecStdin kubectl apply, label nodes (kubectl label via cp —
+   labelLBPrimary pattern, lb.go:327) with the P2 contract labels
+   (`gpu.api=mock`), then bounded polls for DaemonSet readiness and advertised
+   capacity; end with ui.Infof capacity summary + ui.Hintf
+   `kubectl get nodes -o custom-columns=...`.
+4. Wire into both addon blocks (cluster.go:418-430, k3s.go:376-386), degrade on
+   error like observability.
+5. Verify: add `gpu.runtime-class`, `gpu.device-plugin`, and `gpu.nodes` checks,
+   Skip when the addon is absent (verify.go; recon says append-only IDs, never
+   bump SchemaVersion).
+6. webui: add gpu fields to /api/meta + createReq (webui.go:138-147, :380-456);
+   the CLI flag is the real API since webui shells out to kiac.
+7. Tests: gpu_test.go (decodeAll + image-pin regex), configfile_test.go cases,
+   verify test against the fake `container` script.
+Acceptance: on a stock cluster, `kubectl run g --image=busybox --overrides` with
+`kiac.dev/gpu: 1` limits schedules and runs; `kiac verify cluster` passes with
+gpu.* = pass; a cluster created WITHOUT the flag shows gpu.* = skip; `make ci`
+green.
+Demo: helm chart requesting one GPU reconciles on a MacBook with no krunkit.
+
+## P2 — krunkit GPU node backend (the big one; requires P0 pass)
+
+Goal: `kiac create cluster --workers 2 --gpu-workers 1` → mixed cluster: cp +
+workers on apple/container, GPU node(s) on krunkit, joined, labeled, tainted;
+resume/delete/status/verify/stop/start all see them.
+
+### 2a. Backend abstraction (do first, zero behavior change, own PR)
+- Extract a narrow `NodeBackend` in pkg/runtime: RunDetached(RunOpts), Exec,
+  ExecStdin, ExecTimeout, WaitReady, Logs, IP, IPv6, List(prefix) ([]Info,
+  error), Stop, Start, and Remove. Keep apple/container-only host operations
+  (ImagePull/ImageSave, Available, Version, System*, NetworkHasIPv6) on a
+  separate `HostRuntime` interface that embeds NodeBackend. Existing Client
+  implements both unchanged; krunkit must not grow meaningless System* stubs.
+- Manager gains `host HostRuntime` plus a per-node router: `backendFor(node
+  string) NodeBackend` keyed by name suffix (-gpu- → krunkit) with the host
+  backend as default. Enumeration paths use one `listNodes` method that merges
+  all backends. Info gains a `Backend string` field.
+- Fix the leaks: webui.go:180 Runtime().IP → Manager method; cmd/doctor.go and
+  cmd/version.go keep constructing the container client directly (they check
+  the apple/container runtime specifically — fine, note it).
+- Tests: every existing test still green with zero behavior change.
+
+### 2b. krunkit backend implementation (pkg/runtime/krunkit.go)
+- Process model: krunkit is a foreground VMM. RunDetached = spawn krunkit (+
+  vmnet-helper per minikube's documented pairing) detached, write pidfile +
+  state JSON under ~/.kiac/gpu-nodes/<node>.json (image path, disk path, args,
+  MAC, created). List(prefix) reads that registry and synthesizes Info rows —
+  THE fix for the "invisible to container ls" trap (delete would otherwise
+  orphan processes; recon risk list).
+- Exec transport: krunkit has no exec verb. Use SSH: generate a per-cluster
+  ed25519 key under ~/.kiac/gpu-nodes/, inject via cloud-init NoCloud seed ISO
+  at first boot; Exec/ExecStdin/ExecTimeout = ssh -o BatchMode against the node
+  IP. WaitReady for krunkit = wait for SSH, then the distro probe.
+- IP discovery: guest-exec `ip -4 route get 1.1.1.1 ... src` (recon: the ONLY
+  portable path — container.go:268 primary path works once Exec works). For
+  pre-SSH bootstrap, parse /var/db/dhcpd_leases by the VM's MAC.
+- RunOpts translation: parse "2G"-style Memory into MiB, numeric CPUs; ignore
+  Kernel (libkrun boots the disk image's kernel); honor DNS by writing
+  /etc/resolv.conf via cloud-init (krunkit lacks --dns; contract: replace, max
+  3 — dns.go).
+- vRAM window: pass the GPU shm window per P0 findings (krunkit flag if our
+  patch landed, else document the default and set node gpu.memory label from
+  the effective value). NEVER claim a cap we don't set.
+- Fake-ability: struct holds Bin fields (krunkit, vmnet-helper, ssh) so tests
+  stub them with shell scripts, same as runtime.Client{Bin:...}.
+
+### 2c. GPU node image
+- Bootable raw/qcow2 EFI disk image: Fedora 42 base + containerd + kubelet +
+  kubeadm (and k3s binary for the k3s path) + udev rule for /dev/dri
+  permissions + cloud-init enabled. Built by a new GitHub workflow
+  (gpu-image-build.yml; kernel-build.yml is the precedent), published as a
+  release asset, pinned URL+sha256 in a new table in pkg/cluster/gpuimage.go
+  (reuse kernel.go's downloadVerified + ~/.kiac/images/ cache).
+- Note: workload-container Mesa matters (25.0.x era) — the node image only
+  needs kernel virtio-gpu/DRM; document both pins in the image README.
+
+### 2d. Cluster integration
+- Naming grammar — extend ALL FOUR places together (recon risk): status.go:116
+  clusterNameFromNode, cluster.go:763 Clusters(), persist.go:305 orderNodes,
+  chaos.go:106 resolveNode (+ error hints :109-122); ALSO webui.go:192 nodeRole
+  and :493 clusterNode; verify.go:107 layout counting.
+- Create flow: new fields GPUWorkers int, GPUMemory string, GPUImage string in
+  Config + flags + configfile (triple). In Create (cluster.go:170-472): after
+  workers join, boot GPU VMs via the krunkit backend, WaitReady, apply per-node
+  boot prep (ip_forward; senderOffloadFix derived-interface variant — derive
+  NIC from default route like ipv6BootPrep does at cluster.go:77, since eth0 is
+  vmnet-specific), pinKubeletNodeIP ALWAYS (cluster.go:505 pattern; recon:
+  kubelet auto-detect unreliable across vmnet subnets), then kubeadm token
+  join with --node-name (cluster.go:295-320 recipe). k3s path: agent env
+  K3S_URL/K3S_TOKEN at boot (k3s.go:144); token is generated per create — pass
+  it to GPU agents in the same create; for later add-node, read it from the
+  server node.
+- Edge proxy on GPU nodes: run the same three file installs + service start
+  (edgeproxy.go:138-198) over SSH; read the tunnel token from an existing node
+  (/etc/kiac/tunnel.token) — never regenerate (recon risk).
+- Label + taint via cp kubectl after Ready: contract labels + kiac.dev/gpu
+  taint. Device plugin (P1 asset, real mode: mounts /dev/dri, count N) rolls
+  out via nodeSelector gpu.present=true.
+- Reachability preflight: verify GPU-node-IP:6443→cp and host→GPU-node-IP
+  before join (hostReachAPI pattern, reachability.go:23) — vmnet 'default' and
+  vmnet-helper subnets differ; if the host can't reach the GPU node IP,
+  EXCLUDE it from kiac-lb (label it out; lb.go eligible_nodes honors labels via
+  kiac.io/lb-primary precedent) rather than handing out a dead EXTERNAL-IP.
+- Resume: krunkit nodes re-launch from the state registry (process spawn, not
+  `container start`), rediscover IP, then healWorkerScript + re-pin node-ip
+  like any worker (persist.go). Dual-stack: GPU nodes are v4-only initially —
+  skip the IPv6 wait paths for them (recon: nodeIPArg would block 45s and
+  fail); document "GPU nodes join dual clusters v4-only".
+- Delete/cleanupOnFailure: remove krunkit processes + disk images + registry
+  entries; a failed create must not leak host processes.
+- Doctor: extend cmd/doctor.go with krunkit/vmnet-helper presence+version
+  ui.Check lines (gated: only when GPU flags/nodes present). New cmd/gpu.go
+  group: `kiac gpu doctor|status` (status = per-node window, labels, device
+  plugin health). `bench` and `values` come in P3/P4.
+- Verify: `gpu.node.<name>` per-node probe (vulkaninfo-lite: /dev/dri exists,
+  device plugin registered); note verify.go:119 services check must know the
+  GPU node's init story (Fedora systemd — `systemctl is-active containerd
+  kubelet` actually works; k3s GPU agents need the k3s probe).
+- Support bundle: gpu-conditional kubectl outputs + per-node device-plugin log
+  tail keyed on gpu.* != Skip (support.go:148 pattern); ADD redaction regexes
+  for the SSH private key path/content BEFORE collecting anything near it
+  (supportRedactions + TestRedactSupportText).
+Acceptance: mixed 3-node cluster up in one command on kubeadm AND k3s; pod with
+`kiac.dev/gpu: 1` + ramalama image streams tokens with host GPU active in
+Activity Monitor (~75-80% of the P0 native baseline via `kiac gpu bench`
+prototype script); `kiac resume`, `kiac delete`, `kiac get`, `kiac verify`,
+stop/start all handle GPU nodes; failed create leaks no processes; make ci
+green (krunkit faked); runtime-smoke gains a gpu profile (self-hosted).
+
+## P3 — macgpu standalone stack + real scheduling polish
+
+- Create macgpu repo: Helm chart wrapping device-plugin config, labeler
+  (fold into one DaemonSet), RuntimeClass shim; publish pinned images. kiac
+  vendors rendered manifests (gpu_assets.go swaps to macgpu-rendered content,
+  same pins). Chart must install on minikube --driver=krunkit unmodified —
+  that's the ecosystem acceptance test.
+- `kiac gpu bench`: runs the pinned model on (a) host-native llama.cpp/Metal
+  if present, (b) a venus pod, prints tok/s side by side. Honesty artifact.
+- `kiac gpu values <chart>`: emits override files for vllm-production-stack
+  (requestGPUType), kserve (gpu-resource-types annotation), ollama (resources
+  block). Table-driven, tested.
+Acceptance: chart installs on kiac AND minikube-krunkit; bench table prints.
+
+## P4 — nvidia.com/gpu compat bridge
+
+- macgpu repo: mutating webhook (controller-runtime): namespaces labeled
+  `kiac.dev/gpu-compat=nvidia` get nvidia.com/gpu(+mig-*) requests rewritten to
+  kiac.dev/gpu + audit annotation; emits Warning event on detectably-CUDA
+  images ("needs a Vulkan build — see the swap table"). HAMi-DRA's webhook is
+  the pattern precedent. kiac: `kiac gpu compat enable|disable` toggling the
+  namespace label + embedded webhook manifests (cert bootstrap: use a
+  self-signed CA generated at install like other local-first webhooks; keep it
+  simple, document rotation).
+Acceptance: unmodified vLLM production-stack chart with ONLY the documented
+image swap schedules and runs; the rewrite annotation is present; node
+capacity never shows nvidia.com/gpu.
+
+## P5 — DRA driver (first Apple GPU DRA driver)
+
+- macgpu repo: fork/skeleton from kubernetes-sigs/dra-example-driver (CDI
+  plumbing + simulated-device mode = Linux-CI-on-kind for free). Publishes one
+  ResourceSlice device per GPU node: attributes product/api/unified-memory,
+  consumable capacity `memory` = that node's vRAM window. DeviceClass
+  `gpu.kiac.dev` with extendedResourceName `kiac.dev/gpu` (1.37 stable) — the
+  SAME pod YAML from P1 keeps working, now DRA-backed. requestPolicy: 1Gi steps.
+- kiac: install DRA driver instead of device plugin when cluster >= 1.37
+  (flag-gated rollout: `--gpu-resource-driver=dra|device-plugin`, default
+  device-plugin until soak); wire vRAM window value → capacity.
+Acceptance: 8Gi + 24Gi claims admit on a 32Gi-window node, a further 8Gi claim
+is rejected at scheduling with a clear event; simulated mode runs in kind CI;
+`kubectl get resourceslices` shows the device on a MacBook.
+
+## P6 — APIR pool (gated on P0-P5 stable + patch review status re-check)
+
+- Second GPU image flavor carrying virglrenderer !1590 + libkrun #508 builds
+  (crc-org downstream precedent). `--gpu-mode apir` node pools: taint
+  kiac.dev/gpu-apir single-tenant, DRA attribute api=apir, docs state: GGML
+  _VIRTGPU images only, Venus disabled in these VMs, not multitenant safe.
+  `kiac gpu bench` gains the apir column (~95-100% of native llama.cpp).
+  Re-verify patch status upstream before building — they may have merged.
+
+## P7 — Standalone release / P8 — multi-Mac
+
+- P7: macgpu chart verified on minikube-krunkit + Colima k3s with no kiac;
+  host-endpoint addon (`kiac gpu host-endpoint`): registers native
+  llama-server/Ollama/MLX as Service+EndpointSlice, documented as EXTERNAL (no
+  pod sandbox) — LLMKube/Model Runner pattern.
+- P8: `macgpu-node --join <token>` host binary (build/release per the
+  edge-proxy sub-binary precedent: Makefile asset target, reproducible-build
+  check in ci, goreleaser second build id — NOTE release.yml:86 verify step
+  assumes ONE archive; rewrite it when adding the second artifact). Enrolls
+  any Mac's GPU worker into an existing cluster over LAN.
+
+## Risk register (recon-sourced traps; check before each phase)
+
+1. `container ls` is the single inventory: ANY krunkit path missing the
+   registry merge silently orphans VMs (P2a fixes; test delete-after-kill).
+2. Node-name grammar lives in 4+ places; a missed one silently drops GPU nodes
+   from listings (grep for "-worker-" when touching).
+3. distroFromNodes (status.go:95) misclassifies k3s clusters if GPU nodes run
+   non-k3s images — keep at least the k3s-image check semantics; add a test.
+4. WaitReady hardcodes `systemctl is-active containerd`; k3s GPU agents have
+   no systemd — route readiness per distro+backend.
+5. Dual-stack helpers block on IPv6 for v4-only nodes (nodeIPArg 45s wait) —
+   skip for GPU nodes explicitly.
+6. senderOffloadFix hardcodes eth0 — derive the NIC; and verify whether
+   vmnet-helper even needs it (P0 measurement: large NodePort upload through a
+   GPU node).
+7. kiac-lb will hand out any Ready node's IP — gate on host reachability.
+8. configfile KnownFields(true): ship YAML keys with the flags or user configs
+   break.
+9. Support bundle: new secrets (SSH keys, tokens) need redaction regexes FIRST.
+10. Release pipeline assumes one build/one archive — rework release.yml verify
+    + homebrew cask when macgpu-node ships (P8, not before).
+11. Mock/device-plugin images must be linux/arm64 + minimal-kernel-safe (no
+    eBPF) or they crash-loop on the default Apple kernel.
+12. Upstream drift: before P2 and P6, re-check libkrun #765, Mesa blob
+    alignment, virglrenderer !1590, libkrun #508 — any merge simplifies work.
+
+Live dependency status (re-checked 2026-09-04): krunkit v1.3.2 is current;
+libkrun #765 remains open and non-draft with a dirty merge state; libkrun #508
+remains an open draft with a dirty merge state. Treat neither as available.
+Re-check the GitLab virglrenderer MR and Mesa alignment work immediately before
+P6 because their forge state cannot be inferred from the libkrun PRs.
+
+## Suggested execution order for an agent team
+
+- Agent A: P0 spike (scripts + numbers). Agent B in parallel: P1 mock mode.
+- Then P2a (interface extraction, own PR, mergeable independently) → P2b-2d.
+- P3 and P4 parallelize after P2. P5 after P3. P6-P8 sequential, gated.
+- One PR per numbered phase minimum; P2 splits into 2a/2b/2c/2d PRs.
+- Every PR: make ci green, conventions section 4 respected, docs updated
+  (README Features + examples/ lab for each user-visible milestone — the
+  repo's pattern is a lab .md per feature).

--- a/docs/docs/cilium.html
+++ b/docs/docs/cilium.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
@@ -64,6 +65,7 @@ kiac create cluster --name dev --workers 2
 kiac create cluster --memory 8G --cpus 4
 kiac create cluster --distro k3s --workers 1
 kiac create cluster --cni cilium --kernel full
+kiac create cluster --gpu-mock
 kiac create cluster --mount type=bind,source="$PWD",target=/workspace,readonly
 kiac create cluster --config cluster.yaml</code></pre>
   <table>
@@ -87,6 +89,7 @@ kiac create cluster --config cluster.yaml</code></pre>
     <tr><td><code>--no-edge-proxy</code></td><td><code>false</code></td><td>skip the node-local edge proxy that fixes large TCP uploads through NodePorts and LoadBalancers</td></tr>
     <tr><td><code>--observability</code></td><td><code>false</code></td><td>install Prometheus + Grafana + node-exporter, Grafana on a LoadBalancer IP</td></tr>
     <tr><td><code>--gateway</code></td><td><code>false</code></td><td>install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway</td></tr>
+    <tr><td><code>--gpu-mock</code></td><td><code>false</code></td><td>advertise one synthetic <code>kiac.dev/gpu</code> per node and install RuntimeClass <code>kiac-gpu</code> for scheduling tests; no hardware acceleration. See <a href="gpu.html">GPU scheduling alpha</a></td></tr>
     <tr><td><code>--wait</code></td><td><code>5m</code></td><td>timeout for each cluster readiness step, including CNI installation; passed to Cilium as <code>--wait-duration</code></td></tr>
   </table>
   <p>Version resolution: a minor like <code>1.34</code> uses kiac's digest-pinned node image (<code>kindest/node</code>, or <code>rancher/k3s</code> with <code>--distro k3s</code>); an exact patch matches the pin when it is the pinned patch, otherwise falls back to the matching upstream tag unpinned.</p>

--- a/docs/docs/config-file.html
+++ b/docs/docs/config-file.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
@@ -84,7 +85,8 @@ addons:
   loadBalancer: true     <span class="c"># kiac-lb, Services of type LoadBalancer</span>
   edgeProxy: true        <span class="c"># node-local TCP proxy for large external uploads</span>
   observability: false   <span class="c"># Prometheus + Grafana + node-exporter</span>
-  gateway: false         <span class="c"># Gateway API CRDs + Traefik</span></code></pre>
+  gateway: false         <span class="c"># Gateway API CRDs + Traefik</span>
+  gpuMock: false         <span class="c"># scheduling mock only; no GPU acceleration</span></code></pre>
 
   <h2 id="schema">Schema</h2>
   <table>
@@ -106,6 +108,7 @@ addons:
     <tr><td><code>addons.edgeProxy</code></td><td>bool</td><td><code>true</code></td><td><code>--no-edge-proxy</code> (inverted)</td></tr>
     <tr><td><code>addons.observability</code></td><td>bool</td><td><code>false</code></td><td><code>--observability</code></td></tr>
     <tr><td><code>addons.gateway</code></td><td>bool</td><td><code>false</code></td><td><code>--gateway</code></td></tr>
+    <tr><td><code>addons.gpuMock</code></td><td>bool</td><td><code>false</code></td><td><code>--gpu-mock</code> (synthetic scheduling resource; no acceleration)</td></tr>
   </table>
   <p>Notes on the schema:</p>
   <ul>

--- a/docs/docs/contributing.html
+++ b/docs/docs/contributing.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/dashboard.html
+++ b/docs/docs/dashboard.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
@@ -89,7 +90,7 @@ kubectl <span class="k">describe node kiac-dev-worker-1</span></code></pre>
   <h3>Kubeconfig download</h3>
   <p>Every card offers a standalone <code>kiac-&lt;name&gt;.kubeconfig</code> download, self-contained and pointed at the control plane's IP, handy for tools that want their own file instead of your merged <code>~/.kube/config</code>.</p>
   <h3>Create form</h3>
-  <p>The sidebar form covers the common knobs of <code>kiac create cluster</code>: name, workers, distro-specific pinned Kubernetes versions, CPUs and memory per node, CNI, and checkboxes for the kiac-lb LoadBalancer, metrics-server, local-path storage, observability, and Gateway API. Switching distro updates both the available versions and the default. Progress streams into an activity panel showing exactly the log the terminal would print. (<code>--kernel</code> is a CLI-only knob for now.)</p>
+  <p>The sidebar form covers the common knobs of <code>kiac create cluster</code>: name, workers, distro-specific pinned Kubernetes versions, CPUs and memory per node, CNI, and checkboxes for the kiac-lb LoadBalancer, metrics-server, local-path storage, observability, Gateway API, and the explicitly non-accelerated GPU scheduling mock. Switching distro updates both the available versions and the default. Progress streams into an activity panel showing exactly the log the terminal would print. (<code>--kernel</code> is a CLI-only knob for now.)</p>
   <h3>Delete</h3>
   <p>Card-level delete, with a confirmation prompt, equivalent to <code>kiac delete cluster --name &lt;name&gt;</code>.</p>
 

--- a/docs/docs/gateway-api.html
+++ b/docs/docs/gateway-api.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a class="on" href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
@@ -117,7 +118,7 @@ curl http://web.local/</code></pre>
 
   <div class="pn">
     <a href="observability.html"><span>Previous</span>Observability</a>
-    <a class="next" href="labs.html"><span>Next</span>Integration labs</a>
+    <a class="next" href="gpu.html"><span>Next</span>GPU scheduling alpha</a>
   </div>
 </main>
 </div>

--- a/docs/docs/getting-started.html
+++ b/docs/docs/getting-started.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/gpu.html
+++ b/docs/docs/gpu.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GPU scheduling alpha · kiac docs</title>
+<meta name="description" content="Test GPU-shaped Kubernetes workloads with kiac's opt-in mock scheduling resource while the real Apple GPU backend is developed.">
+<link rel="icon" type="image/svg+xml" href="../assets/logo-mark.svg">
+<link rel="stylesheet" href="docs.css">
+</head>
+<body>
+<input type="checkbox" id="menu">
+<header><div class="hin">
+  <a class="brand" href="../index.html"><img src="../assets/logo-mark.svg" alt="kiac"> kiac</a>
+  <a class="crumb" href="index.html">Docs</a>
+  <span class="spacer"></span>
+  <label for="menu" class="mtoggle">Menu</label>
+  <a class="gh" href="https://github.com/saiyam1814/kiac">GitHub</a>
+</div></header>
+<div class="wrap">
+<aside>
+  <div class="group"><div class="glabel">Start here</div>
+    <a href="index.html">Overview &amp; install</a>
+    <a href="getting-started.html">Getting started</a>
+  </div>
+  <div class="group"><div class="glabel">Core concepts</div>
+    <a href="networking.html">Networking</a>
+    <a href="storage-and-metrics.html">Storage &amp; metrics</a>
+    <a href="config-file.html">Config file</a>
+    <a href="cli-reference.html">CLI reference</a>
+  </div>
+  <div class="group"><div class="glabel">Distros &amp; kernels</div>
+    <a href="k3s.html">k3s distro</a>
+    <a href="cilium.html">Cilium &amp; the full kernel</a>
+  </div>
+  <div class="group"><div class="glabel">Built-in addons</div>
+    <a href="observability.html">Observability</a>
+    <a href="gateway-api.html">Gateway API</a>
+    <a class="on" href="gpu.html">GPU scheduling alpha</a>
+  </div>
+  <div class="group"><div class="glabel">Hands-on</div>
+    <a href="labs.html">Integration labs</a>
+    <a href="portainer.html">Portainer on kiac</a>
+    <a href="rancher.html">Rancher on kiac</a>
+  </div>
+  <div class="group"><div class="glabel">Day two</div>
+    <a href="node-chaos.html">Node chaos</a>
+    <a href="persistence.html">Reboots &amp; resume</a>
+    <a href="dashboard.html">Dashboard (kiac ui)</a>
+    <a href="troubleshooting.html">Troubleshooting</a>
+  </div>
+  <div class="group"><div class="glabel">Project</div>
+    <a href="contributing.html">Contributing</a>
+  </div>
+</aside>
+<main>
+  <div class="kicker">Alpha</div>
+  <h1>GPU scheduling</h1>
+  <p class="lede">Exercise GPU-aware charts and Kubernetes scheduling contracts today, without pretending the Apple GPU is already available inside a node VM.</p>
+
+  <div class="note"><b>No hardware acceleration in mock mode</b>
+  <code>--gpu-mock</code> advertises a synthetic extended resource. It does not expose the Apple GPU, Metal, CUDA, or Vulkan acceleration.</div>
+
+  <pre><code>kiac create cluster --name gpu-lab --workers 2 --gpu-mock</code></pre>
+  <p>The flag works on both kubeadm and k3s. It is fully opt-in: clusters created without it have no device-plugin Pods and no additional startup or idle overhead.</p>
+
+  <h2 id="contract">What gets installed</h2>
+  <table>
+    <tr><th>Piece</th><th>Contract</th></tr>
+    <tr><td>Extended resource</td><td>One synthetic <code>kiac.dev/gpu</code> on every current node</td></tr>
+    <tr><td>RuntimeClass</td><td><code>kiac-gpu</code>, passed through to the existing <code>runc</code> handler</td></tr>
+    <tr><td>Device plugin</td><td><code>squat/generic-device-plugin</code> 0.2.0, pinned by multi-architecture digest, in <code>kiac-gpu-system</code></td></tr>
+    <tr><td>Allocation marker</td><td>The harmless node device <code>/dev/null</code>, mounted into requesting Pods at <code>/dev/kiac-mock-gpu</code></td></tr>
+    <tr><td>Node labels</td><td><code>gpu.present=true</code>, <code>product=Mock</code>, <code>memory=0</code>, <code>count=1</code>, <code>api=mock</code>, all under the <code>kiac.dev/</code> prefix</td></tr>
+  </table>
+
+  <h2 id="run">Run the check</h2>
+  <pre><code>kubectl apply -f https://raw.githubusercontent.com/saiyam1814/kiac/main/examples/gpu-mock.yaml
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded \
+  pod/kiac-gpu-mock-check --timeout=2m
+kubectl logs pod/kiac-gpu-mock-check
+
+<span class="o">mock GPU scheduling works; no hardware acceleration is enabled</span></code></pre>
+  <p>The example requests <code>kiac.dev/gpu: 1</code>, sets <code>runtimeClassName: kiac-gpu</code>, and checks that allocation created the character device marker. kiac deliberately avoids the name <code>nvidia</code>, which distributions such as k3s may already own for a real vendor runtime. Follow the full <a href="https://github.com/saiyam1814/kiac/blob/main/examples/gpu-mock-lab.md">mock GPU lab</a> to inspect capacity, labels, verification, and cleanup.</p>
+
+  <h2 id="verify">Verify it</h2>
+  <pre><code>kiac verify cluster --name gpu-lab
+kubectl get nodes -l kiac.dev/gpu.present=true
+kubectl get daemonset -n kiac-gpu-system</code></pre>
+  <p><code>verify</code> checks the RuntimeClass handler, DaemonSet rollout, label contract, advertised capacity, and every GPU-labeled node. On a cluster without the flag, the global GPU checks report <code>skip</code>.</p>
+
+  <h2 id="next">Path to real acceleration</h2>
+  <p>The next backend uses krunkit/Venus GPU VMs as dedicated workers while keeping the workload-facing resource and labels stable. It is gated on a reproducible one-VM and two-VM performance spike, process lifecycle, SSH transport, mixed-backend inventory, and upstream libkrun work. The exact phases and current blockers are in the <a href="https://github.com/saiyam1814/kiac/blob/main/docs/design/gpu-build-plan.md">GPU build plan</a>.</p>
+
+  <div class="pn">
+    <a href="gateway-api.html"><span>Previous</span>Gateway API</a>
+    <a class="next" href="labs.html"><span>Next</span>Integration labs</a>
+  </div>
+</main>
+</div>
+</body>
+</html>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>
@@ -71,7 +72,8 @@
     <li><b>Clusters survive reboots.</b> <code>kiac resume cluster</code> boots the VMs back up after a host reboot and heals everything the new IPs broke. See <a href="persistence.html">Reboots &amp; resume</a>.</li>
     <li><b>Optional observability.</b> <code>--observability</code> installs Prometheus and Grafana with dashboards already provisioned. See <a href="observability.html">Observability</a>.</li>
     <li><b>Optional Gateway API.</b> <code>--gateway</code> installs the Gateway API CRDs and Traefik with a ready-to-use Gateway. See <a href="gateway-api.html">Gateway API</a>.</li>
-    <li><b>Optional applications and verified examples.</b> Run <a href="portainer.html">Portainer CE</a> or <a href="rancher.html">Rancher Manager</a> on kiac, or follow repeatable workflows for Gateway API, observability, k8gb, OpenChoreo, node failure, and reboot recovery. Browse <a href="labs.html">all integration labs</a>.</li>
+    <li><b>GPU scheduling alpha.</b> <code>--gpu-mock</code> lets GPU-shaped charts request <code>kiac.dev/gpu</code> through RuntimeClass <code>kiac-gpu</code>. It validates scheduling only and provides no acceleration. See <a href="gpu.html">GPU scheduling alpha</a>.</li>
+    <li><b>Optional applications and verified examples.</b> Run <a href="portainer.html">Portainer CE</a> or <a href="rancher.html">Rancher Manager</a> on kiac, or follow repeatable workflows for Gateway API, observability, mock GPU scheduling, k8gb, OpenChoreo, node failure, and reboot recovery. Browse <a href="labs.html">all integration labs</a>.</li>
     <li><b>Node chaos.</b> <code>kiac stop node</code> / <code>kiac start node</code> stop and restart a real node VM. See <a href="node-chaos.html">Node chaos</a>.</li>
     <li><b>A local dashboard.</b> <code>kiac ui</code> opens a web console with cluster cards, live resource bars, a kubectl console drawer, and a create form. See <a href="dashboard.html">Dashboard</a>.</li>
   </ul>

--- a/docs/docs/k3s.html
+++ b/docs/docs/k3s.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/labs.html
+++ b/docs/docs/labs.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a class="on" href="labs.html">Integration labs</a>
@@ -87,12 +88,13 @@
   <div class="lab-actions"><a href="rancher.html">Run Rancher on kiac</a><a href="https://github.com/saiyam1814/kiac/blob/main/examples/rancher.sh">Installation script</a></div>
   <p>The script uses a dedicated cluster because Rancher creates cluster-wide controllers, roles, webhooks, custom resources, and system namespaces. Cleanup deletes that owned cluster instead of attempting a partial uninstall from an unrelated environment.</p>
 
-  <h2 id="addons">Gateway API and observability</h2>
+  <h2 id="addons">Built-in addon labs</h2>
   <p>These labs exercise kiac's built-in addons through their user-facing endpoints:</p>
   <table>
     <tr><th>Lab</th><th>What it proves</th></tr>
     <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/gateway-api-lab.md">Gateway API</a></td><td>GatewayClass and Gateway readiness, HTTPRoute attachment, hostname and path matching, and traffic through the assigned LoadBalancer IP.</td></tr>
     <tr><td><a href="https://github.com/saiyam1814/kiac/blob/main/examples/observability-lab.md">Observability</a></td><td>Grafana access, Prometheus target discovery, application metrics, generated traffic, and metric queries.</td></tr>
+    <tr><td><a href="gpu.html">GPU scheduling alpha</a></td><td>A GPU-shaped Pod requests <code>kiac.dev/gpu</code>, uses RuntimeClass <code>kiac-gpu</code>, and verifies allocation of the mock marker device. This mode does not accelerate workloads.</td></tr>
   </table>
 
   <h2 id="multi-cluster">Multi-cluster and platform labs</h2>
@@ -113,7 +115,7 @@
   Integrations stay outside the kiac binary unless they are part of the local-cluster foundation. This keeps startup fast and lets each workload declare its own security and resource cost.</div>
 
   <div class="pn">
-    <a href="gateway-api.html"><span>Previous</span>Gateway API</a>
+    <a href="gpu.html"><span>Previous</span>GPU scheduling alpha</a>
     <a class="next" href="portainer.html"><span>Next</span>Portainer on kiac</a>
   </div>
 </main>

--- a/docs/docs/networking.html
+++ b/docs/docs/networking.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/node-chaos.html
+++ b/docs/docs/node-chaos.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/observability.html
+++ b/docs/docs/observability.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a class="on" href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/persistence.html
+++ b/docs/docs/persistence.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/portainer.html
+++ b/docs/docs/portainer.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/rancher.html
+++ b/docs/docs/rancher.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/storage-and-metrics.html
+++ b/docs/docs/storage-and-metrics.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/docs/docs/troubleshooting.html
+++ b/docs/docs/troubleshooting.html
@@ -36,6 +36,7 @@
   <div class="group"><div class="glabel">Built-in addons</div>
     <a href="observability.html">Observability</a>
     <a href="gateway-api.html">Gateway API</a>
+    <a href="gpu.html">GPU scheduling alpha</a>
   </div>
   <div class="group"><div class="glabel">Hands-on</div>
     <a href="labs.html">Integration labs</a>

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ kubectl apply -f https://raw.githubusercontent.com/saiyam1814/kiac/main/examples
 | [statefulset.yaml](statefulset.yaml) | StatefulSet with `volumeClaimTemplates` on the bundled local-path default StorageClass; PVCs bind, data survives pod restarts. |
 | [httproute.yaml](httproute.yaml) | Hostname routing with Gateway API: an echo app plus an HTTPRoute attached to the default Gateway from `--gateway`; needs a cluster created with `--gateway`. |
 | [observability-scrape.yaml](observability-scrape.yaml) | Two pod annotations get your app's metrics into the bundled Prometheus and Grafana; needs a cluster created with `--observability`. |
+| [gpu-mock.yaml](gpu-mock.yaml) | A Pod requesting `kiac.dev/gpu` through RuntimeClass `kiac-gpu`; needs `--gpu-mock` and validates scheduling only, with no acceleration. |
 
 ## Guides and config files
 
@@ -34,13 +35,14 @@ kubectl apply -f https://raw.githubusercontent.com/saiyam1814/kiac/main/examples
 | [k3s-cluster.md](k3s-cluster.md) | k3s as the node distro: what k3s bundles, what kiac changes, the PVC and LoadBalancer examples running on it unchanged, and the footprint. |
 | [observability-lab.md](observability-lab.md) | Step-by-step Grafana/Prometheus lab: create `--observability`, scrape an annotated app, query Prometheus, and optionally pair it with Gateway API. |
 | [gateway-api-lab.md](gateway-api-lab.md) | Step-by-step Gateway API lab: inspect GatewayClass and Gateway, attach HTTPRoutes, test hostname/path matching, and troubleshoot route status. |
+| [gpu-mock-lab.md](gpu-mock-lab.md) | Alpha GPU scheduling lab: inspect labels and capacity, run a GPU-shaped Pod, verify the marker device, and understand what is deliberately not accelerated yet. |
 | [chaos-drill.md](chaos-drill.md) | Step-by-step node-failure drill: spread an app across workers, `kiac stop node`, watch eviction and reschedule, `kiac start node`, watch the rejoin. |
 | [resume-drill.md](resume-drill.md) | Reboot-survival drill: stop the container system, see `0/3 stopped` in `kiac get clusters`, bring it all back with `kiac resume`, curl the app again. |
 | [k8gb-lab.md](k8gb-lab.md) | Real DNS-based failover across two kiac clusters: lightweight edge DNS, delegated regional CoreDNS, HTTP traffic validation, failover, and failback. |
 | [portainer-lab.md](portainer-lab.md) | Portainer CE on a pinned Kubernetes 1.34 cluster: persistent data, a real LoadBalancer address, protected admin credentials, and authenticated API verification. |
 | [rancher-lab.md](rancher-lab.md) | Rancher Manager on a dedicated Kubernetes 1.34 cluster: Gateway API, local TLS, protected credentials, authenticated API verification, and owned cleanup. |
 | [cluster.yaml](cluster.yaml) | Minimal `--config` file for `kiac create cluster`. |
-| [cluster-full.yaml](cluster-full.yaml) | `--config` file with every knob set and commented, all addons on including observability and gateway. |
+| [cluster-full.yaml](cluster-full.yaml) | `--config` file with every knob set and commented, including the optional stacks and mock GPU scheduling. |
 
 ## Notes
 

--- a/examples/cluster-full.yaml
+++ b/examples/cluster-full.yaml
@@ -68,8 +68,8 @@ memory: 4G
 # Timeout for nodes to become Ready. Default: 5m.
 wait: 5m
 
-# Addons are positive toggles (true installs). The first three default
-# to true, the last two to false; everything is on here.
+# Addons are positive toggles (true installs). The foundational addons
+# default to true; optional stacks and mock GPU scheduling default false.
 addons:
   # metrics-server: kubectl top nodes / kubectl top pods.
   metrics: true
@@ -102,3 +102,8 @@ addons:
   # examples/httproute.yaml). Grafana and Traefik share one
   # LoadBalancer IP (ports 3000 vs 80/443).
   gateway: true
+
+  # Alpha scheduling harness: exposes one synthetic kiac.dev/gpu per node,
+  # the RuntimeClass "kiac-gpu", and /dev/kiac-mock-gpu inside requesting
+  # Pods. This does NOT expose or accelerate with the Apple GPU.
+  gpuMock: true

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -30,3 +30,4 @@ addons:
   edgeProxy: true        # node-local TCP proxy for large external uploads
   observability: false   # Prometheus + Grafana + node-exporter
   gateway: false         # Gateway API CRDs + Traefik
+  gpuMock: false         # mock kiac.dev/gpu scheduling; no acceleration

--- a/examples/gpu-mock-lab.md
+++ b/examples/gpu-mock-lab.md
@@ -1,0 +1,71 @@
+# Mock GPU scheduling lab
+
+This lab exercises kiac's first GPU alpha contract on an ordinary Apple
+container cluster. It proves that Kubernetes charts can discover a GPU-labeled
+node, request `kiac.dev/gpu`, and use `runtimeClassName: kiac-gpu`.
+
+**This mode does not expose the Apple GPU and does not accelerate workloads.**
+It is a scheduling and compatibility harness for the real krunkit/Venus backend
+planned next.
+
+## 1. Create an opt-in mock cluster
+
+```bash
+kiac create cluster --name gpu-lab --workers 2 --gpu-mock
+kubectl config use-context kiac-gpu-lab
+```
+
+Without `--gpu-mock`, kiac creates exactly the same cluster as before and runs
+no device-plugin Pods.
+
+## 2. Inspect the contract
+
+```bash
+kubectl get runtimeclass kiac-gpu -o custom-columns=NAME:.metadata.name,HANDLER:.handler
+kubectl get daemonset -n kiac-gpu-system kiac-gpu-device-plugin
+kubectl get nodes -l kiac.dev/gpu.present=true \
+  -o 'custom-columns=NAME:.metadata.name,GPU:.status.capacity.kiac\.dev/gpu,PRODUCT:.metadata.labels.kiac\.dev/gpu\.product,API:.metadata.labels.kiac\.dev/gpu\.api'
+```
+
+Every current node advertises one synthetic `kiac.dev/gpu`. The labels say
+`product=Mock`, `count=1`, `memory=0`, and `api=mock`, so automation can reject
+mock nodes when it needs real acceleration.
+
+## 3. Schedule a GPU-shaped Pod
+
+```bash
+kubectl apply -f examples/gpu-mock.yaml
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded \
+  pod/kiac-gpu-mock-check --timeout=2m
+kubectl logs pod/kiac-gpu-mock-check
+kubectl get pod kiac-gpu-mock-check -o wide
+```
+
+Expected log:
+
+```text
+mock GPU scheduling works; no hardware acceleration is enabled
+```
+
+The device plugin maps the node's harmless `/dev/null` character device to
+`/dev/kiac-mock-gpu` in this Pod. This confirms allocation happened; it is not a
+CUDA, Metal, or Vulkan device.
+
+## 4. Verify and clean up
+
+```bash
+kiac verify cluster --name gpu-lab
+kubectl delete -f examples/gpu-mock.yaml
+kiac delete cluster --name gpu-lab
+```
+
+`verify` reports `gpu.runtime-class`, `gpu.device-plugin`, `gpu.nodes`, and one
+`gpu.node.<node-name>` check per labeled node. On clusters created without the
+flag, the three global GPU checks report `skip`.
+
+## What comes next
+
+The stable target keeps the workload-facing resource and labels while replacing
+the marker device with a real `/dev/dri` path from krunkit/Venus GPU nodes. The
+validation spike and backend work are tracked in
+[`docs/design/gpu-build-plan.md`](../docs/design/gpu-build-plan.md).

--- a/examples/gpu-mock.yaml
+++ b/examples/gpu-mock.yaml
@@ -1,0 +1,37 @@
+# Mock GPU scheduling check. This Pod requests the alpha kiac.dev/gpu
+# resource and the kiac-specific RuntimeClass installed by:
+#
+#   kiac create cluster --name gpu-lab --gpu-mock
+#   kubectl apply -f examples/gpu-mock.yaml
+#   kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/kiac-gpu-mock-check --timeout=2m
+#   kubectl logs pod/kiac-gpu-mock-check
+#
+# Mock mode validates scheduling and chart compatibility only. It exposes
+# /dev/kiac-mock-gpu as a harmless marker and provides no GPU acceleration.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kiac-gpu-mock-check
+  labels:
+    app.kubernetes.io/name: kiac-gpu-mock-check
+spec:
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  runtimeClassName: kiac-gpu
+  containers:
+    - name: check
+      image: docker.io/library/busybox:1.37.0
+      command: [sh, -ec]
+      args:
+        - |
+          test -c /dev/kiac-mock-gpu
+          echo "mock GPU scheduling works; no hardware acceleration is enabled"
+      resources:
+        requests:
+          kiac.dev/gpu: "1"
+        limits:
+          kiac.dev/gpu: "1"
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]

--- a/pkg/cluster/assets/gpu/device-plugin.yaml
+++ b/pkg/cluster/assets/gpu/device-plugin.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kiac-gpu-device-plugin
+  namespace: kiac-gpu-system
+  labels:
+    app.kubernetes.io/name: kiac-gpu-device-plugin
+    app.kubernetes.io/part-of: kiac
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiac-gpu-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kiac-gpu-device-plugin
+        app.kubernetes.io/part-of: kiac
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: generic-device-plugin
+          image: docker.io/squat/generic-device-plugin:0.2.0@sha256:66c8d5c270eb2b721f1064c549b9b7898152a6d2f0163380a5d37dc7636c20ff
+          imagePullPolicy: IfNotPresent
+          args:
+            - --domain=kiac.dev
+            - --device
+            - |-
+              name: gpu
+              groups:
+                - count: 1
+                  paths:
+                    - path: /dev/null
+                      mountPath: /dev/kiac-mock-gpu
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: device-plugins
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugins
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: Directory

--- a/pkg/cluster/assets/gpu/namespace.yaml
+++ b/pkg/cluster/assets/gpu/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kiac-gpu-system
+  labels:
+    app.kubernetes.io/name: kiac-gpu
+    app.kubernetes.io/part-of: kiac
+    kiac.dev/gpu.api: mock

--- a/pkg/cluster/assets/gpu/runtimeclass.yaml
+++ b/pkg/cluster/assets/gpu/runtimeclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kiac-gpu
+  labels:
+    app.kubernetes.io/managed-by: kiac
+handler: runc

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -121,6 +121,7 @@ type Config struct {
 	NoEdgeProxy   bool
 	Observability bool
 	Gateway       bool
+	GPUMock       bool
 	WaitTimeout   time.Duration
 }
 
@@ -194,6 +195,9 @@ func (m *Manager) Create(cfg Config) error {
 	}
 	if err := runtime.ValidateMounts(cfg.Mounts); err != nil {
 		return err
+	}
+	if cfg.GPUMock && cfg.CNI == "none" {
+		return fmt.Errorf("--gpu-mock needs a working CNI; remove --cni none")
 	}
 
 	// Fail cilium prerequisites before any VM boots, not minutes later
@@ -415,8 +419,8 @@ func (m *Manager) Create(cfg Config) error {
 		}
 	}
 
-	// Optional addons ride after the primary label: both expose Services
-	// of type LoadBalancer and want an EXTERNAL-IP assignable immediately.
+	// Optional addons ride after nodes are Ready. Observability and Gateway
+	// also use the primary label for immediately assignable LoadBalancer IPs.
 	// Failures degrade the cluster rather than tearing it down.
 	if cfg.Observability && cfg.CNI != "none" {
 		if err := m.installObservability(cp, cfg); err != nil {
@@ -426,6 +430,11 @@ func (m *Manager) Create(cfg Config) error {
 	if cfg.Gateway && cfg.CNI != "none" {
 		if err := m.installGateway(cp, cfg); err != nil {
 			ui.Infof("gateway stack not installed: %v", err)
+		}
+	}
+	if cfg.GPUMock && cfg.CNI != "none" {
+		if err := m.installGPU(cp, cfg); err != nil {
+			ui.Infof("mock GPU scheduling not installed: %v", err)
 		}
 	}
 

--- a/pkg/cluster/configfile.go
+++ b/pkg/cluster/configfile.go
@@ -32,8 +32,8 @@ type FileConfig struct {
 }
 
 // FileAddons toggles the optional cluster addons. Omitted keys keep the
-// CLI defaults: metrics, storage, and loadBalancer on; observability
-// and gateway off.
+// CLI defaults: metrics, storage, and loadBalancer on; observability,
+// gateway, and mock GPU scheduling off.
 type FileAddons struct {
 	Metrics       *bool `yaml:"metrics"`
 	Storage       *bool `yaml:"storage"`
@@ -41,6 +41,7 @@ type FileAddons struct {
 	EdgeProxy     *bool `yaml:"edgeProxy"`
 	Observability *bool `yaml:"observability"`
 	Gateway       *bool `yaml:"gateway"`
+	GPUMock       *bool `yaml:"gpuMock"`
 }
 
 // LoadConfigFile parses a cluster config file. Unknown keys are an
@@ -133,6 +134,9 @@ func (fc *FileConfig) Merge(cfg *Config, k8sVersion *string, changed func(string
 	}
 	if fc.Addons.Gateway != nil && !changed("gateway") {
 		cfg.Gateway = *fc.Addons.Gateway
+	}
+	if fc.Addons.GPUMock != nil && !changed("gpu-mock") {
+		cfg.GPUMock = *fc.Addons.GPUMock
 	}
 	return nil
 }

--- a/pkg/cluster/configfile_test.go
+++ b/pkg/cluster/configfile_test.go
@@ -49,6 +49,7 @@ addons:
   edgeProxy: false
   observability: true
   gateway: true
+  gpuMock: true
 `,
 			check: func(t *testing.T, fc *FileConfig) {
 				if fc.Name != "demo" || fc.Workers == nil || *fc.Workers != 3 {
@@ -70,8 +71,8 @@ addons:
 				if a.Metrics == nil || *a.Metrics || a.Storage == nil || *a.Storage || a.LoadBalancer == nil || *a.LoadBalancer || a.EdgeProxy == nil || *a.EdgeProxy {
 					t.Errorf("metrics/storage/loadBalancer/edgeProxy = %v/%v/%v/%v", a.Metrics, a.Storage, a.LoadBalancer, a.EdgeProxy)
 				}
-				if a.Observability == nil || !*a.Observability || a.Gateway == nil || !*a.Gateway {
-					t.Errorf("observability/gateway = %v/%v", a.Observability, a.Gateway)
+				if a.Observability == nil || !*a.Observability || a.Gateway == nil || !*a.Gateway || a.GPUMock == nil || !*a.GPUMock {
+					t.Errorf("observability/gateway/gpuMock = %v/%v/%v", a.Observability, a.Gateway, a.GPUMock)
 				}
 			},
 		},
@@ -82,7 +83,7 @@ addons:
 				if fc.Workers != nil {
 					t.Errorf("workers = %v, want nil", fc.Workers)
 				}
-				if fc.Addons.Metrics != nil || fc.Addons.Gateway != nil {
+				if fc.Addons.Metrics != nil || fc.Addons.Gateway != nil || fc.Addons.GPUMock != nil {
 					t.Errorf("addons = %+v, want all nil", fc.Addons)
 				}
 			},
@@ -185,6 +186,7 @@ func TestMerge(t *testing.T) {
 			EdgeProxy:     boolPtr(false),
 			Observability: boolPtr(true),
 			Gateway:       boolPtr(true),
+			GPUMock:       boolPtr(true),
 		},
 	}
 
@@ -210,7 +212,7 @@ func TestMerge(t *testing.T) {
 				Memory:    "8G",
 				CPMemory:  "4G",
 				NoMetrics: true, NoStorage: true, NoLB: true, NoEdgeProxy: true,
-				Observability: true, Gateway: true,
+				Observability: true, Gateway: true, GPUMock: true,
 				WaitTimeout: 10 * time.Minute,
 			},
 			wantVersion: "1.34",
@@ -243,7 +245,7 @@ func TestMerge(t *testing.T) {
 				Memory:    "8G",
 				CPMemory:  "4G",
 				NoMetrics: false, NoStorage: true, NoLB: true, NoEdgeProxy: true,
-				Observability: true, Gateway: true,
+				Observability: true, Gateway: true, GPUMock: true,
 				WaitTimeout: 5 * time.Minute,
 			},
 			wantVersion: "1.36",
@@ -251,7 +253,7 @@ func TestMerge(t *testing.T) {
 		{
 			name:    "explicit addon flags override file toggles",
 			file:    full,
-			changed: map[string]bool{"observability": true, "gateway": true, "no-lb": true, "no-edge-proxy": true},
+			changed: map[string]bool{"observability": true, "gateway": true, "gpu-mock": true, "no-lb": true, "no-edge-proxy": true},
 			wantCfg: Config{
 				Name: "demo", Workers: 3,
 				Image:     "docker.io/kindest/node:v1.34.8",
@@ -284,7 +286,7 @@ func TestMerge(t *testing.T) {
 				Memory:    "8G",
 				CPMemory:  "4G",
 				NoMetrics: true, NoStorage: true, NoLB: true, NoEdgeProxy: true,
-				Observability: true, Gateway: true,
+				Observability: true, Gateway: true, GPUMock: true,
 				WaitTimeout: 10 * time.Minute,
 			},
 			wantVersion: "1.34",
@@ -306,7 +308,7 @@ func TestMerge(t *testing.T) {
 				Memory:    "8G",
 				CPMemory:  "4G",
 				NoMetrics: true, NoStorage: true, NoLB: true, NoEdgeProxy: true,
-				Observability: true, Gateway: true,
+				Observability: true, Gateway: true, GPUMock: true,
 				WaitTimeout: 10 * time.Minute,
 			},
 			wantVersion: "1.34",
@@ -367,7 +369,24 @@ func TestLoadAndMergeExample(t *testing.T) {
 	if cfg.Name != "dev" || cfg.Workers != 2 || version != "1.36" {
 		t.Errorf("example merged to name=%q workers=%d version=%q", cfg.Name, cfg.Workers, version)
 	}
-	if cfg.NoMetrics || cfg.NoStorage || cfg.NoLB || cfg.Observability || cfg.Gateway {
+	if cfg.NoMetrics || cfg.NoStorage || cfg.NoLB || cfg.Observability || cfg.Gateway || cfg.GPUMock {
 		t.Errorf("example addons should match defaults, got %+v", cfg)
+	}
+}
+
+func TestLoadAndMergeFullExample(t *testing.T) {
+	fc, err := LoadConfigFile("../../examples/cluster-full.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, version := cliDefaults()
+	if err := fc.Merge(&cfg, &version, func(string) bool { return false }); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Name != "full" || cfg.Workers != 3 || cfg.CNI != "kindnet" || version != "1.36" {
+		t.Errorf("full example merged to name=%q workers=%d cni=%q version=%q", cfg.Name, cfg.Workers, cfg.CNI, version)
+	}
+	if cfg.NoMetrics || cfg.NoStorage || cfg.NoLB || cfg.NoEdgeProxy || !cfg.Observability || !cfg.Gateway || !cfg.GPUMock {
+		t.Errorf("full example should enable every addon, got %+v", cfg)
 	}
 }

--- a/pkg/cluster/gpu.go
+++ b/pkg/cluster/gpu.go
@@ -1,0 +1,131 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/saiyam1814/kiac/pkg/ui"
+)
+
+const gpuResourceDomain = "kiac.dev"
+
+// GPUResourceName is the extended resource advertised by the GPU alpha.
+const GPUResourceName = gpuResourceDomain + "/gpu"
+
+const (
+	gpuNamespace       = "kiac-gpu-system"
+	gpuDevicePlugin    = "kiac-gpu-device-plugin"
+	gpuLabelPresent    = gpuResourceDomain + "/gpu.present"
+	gpuLabelProduct    = gpuResourceDomain + "/gpu.product"
+	gpuLabelMemory     = gpuResourceDomain + "/gpu.memory"
+	gpuLabelCount      = gpuResourceDomain + "/gpu.count"
+	gpuLabelAPI        = gpuResourceDomain + "/gpu.api"
+	gpuMockDevicePath  = "/dev/kiac-mock-gpu"
+	gpuRuntimeClass    = "kiac-gpu"
+	defaultGPUWaitTime = 5 * time.Minute
+)
+
+// installGPUMock exposes one synthetic extended resource on every current
+// node. It proves chart scheduling and runtime contracts on ordinary kiac
+// clusters; /dev/null is mounted at gpuMockDevicePath and no GPU is exposed.
+func (m *Manager) installGPUMock(cp string, cfg Config, kubeconfig string) error {
+	manifest := strings.Join(gpuMockManifests(), "\n---\n")
+	if err := ui.Step("Installing mock GPU scheduling", func() error {
+		return m.rt.ExecStdin(cp, strings.NewReader(manifest),
+			"kubectl", "--kubeconfig", kubeconfig, "apply", "-f", "-")
+	}); err != nil {
+		return err
+	}
+
+	if err := ui.Step("Labeling mock GPU nodes", func() error {
+		_, err := m.rt.Exec(cp, "kubectl", "--kubeconfig", kubeconfig,
+			"label", "nodes", "--all",
+			gpuLabelPresent+"=true",
+			gpuLabelProduct+"=Mock",
+			gpuLabelMemory+"=0",
+			gpuLabelCount+"=1",
+			gpuLabelAPI+"=mock",
+			"--overwrite")
+		return err
+	}); err != nil {
+		return err
+	}
+
+	timeout := cfg.WaitTimeout
+	if timeout <= 0 {
+		timeout = defaultGPUWaitTime
+	}
+	if err := ui.Step("Waiting for mock GPU capacity", func() error {
+		started := time.Now()
+		if _, err := m.rt.Exec(cp, "kubectl", "--kubeconfig", kubeconfig,
+			"rollout", "status", "daemonset/"+gpuDevicePlugin, "-n", gpuNamespace,
+			"--timeout="+timeout.String()); err != nil {
+			return err
+		}
+		remaining := timeout - time.Since(started)
+		if remaining <= 0 {
+			return fmt.Errorf("mock GPU device plugin became ready after the %s timeout", timeout)
+		}
+		return m.waitForGPUMockCapacity(cp, kubeconfig, 1+cfg.Workers, remaining)
+	}); err != nil {
+		return err
+	}
+
+	ui.Infof("Mock GPU scheduling ready: %s=1 on %d node(s); no hardware acceleration is enabled", GPUResourceName, 1+cfg.Workers)
+	ui.Hintf("kubectl get nodes -l %s=true -o custom-columns=NAME:.metadata.name,GPU:.status.capacity.%s,API:.metadata.labels.%s", gpuLabelPresent, escapedJSONPathKey(GPUResourceName), escapedJSONPathKey(gpuLabelAPI))
+	return nil
+}
+
+func (m *Manager) installGPU(cp string, cfg Config) error {
+	return m.installGPUMock(cp, cfg, adminConf)
+}
+
+func (m *Manager) installGPUK3s(cp string, cfg Config) error {
+	return m.installGPUMock(cp, cfg, k3sKubeconfig)
+}
+
+func (m *Manager) waitForGPUMockCapacity(cp, kubeconfig string, want int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	last := "no labeled nodes reported capacity"
+	for {
+		out, err := m.rt.Exec(cp, "kubectl", "--kubeconfig", kubeconfig,
+			"get", "nodes", "-l", gpuLabelPresent+"=true", "-o", "json")
+		if err == nil {
+			var nodes kubeNodeList
+			if err := json.Unmarshal([]byte(out), &nodes); err != nil {
+				last = "cannot parse node capacity: " + err.Error()
+			} else {
+				ready := 0
+				for _, node := range nodes.Items {
+					if positiveResourceQuantity(node.Status.Capacity[GPUResourceName]) {
+						ready++
+					}
+				}
+				last = fmt.Sprintf("%d/%d node(s) advertise %s", ready, want, GPUResourceName)
+				if len(nodes.Items) == want && ready == want {
+					return nil
+				}
+			}
+		} else {
+			last = err.Error()
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("mock GPU capacity was not ready within %s: %s; check: kubectl get pods -n %s -o wide", timeout, compact(last), gpuNamespace)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func positiveResourceQuantity(value string) bool {
+	n, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	return err == nil && n > 0
+}
+
+// escapedJSONPathKey turns a qualified key into kubectl's custom-columns key
+// syntax, where dots in map keys must be escaped but the slash is literal.
+func escapedJSONPathKey(key string) string {
+	return strings.ReplaceAll(key, ".", `\.`)
+}

--- a/pkg/cluster/gpu_assets.go
+++ b/pkg/cluster/gpu_assets.go
@@ -1,0 +1,25 @@
+package cluster
+
+import _ "embed"
+
+// The mock GPU addon is intentionally small: a namespace, a pass-through
+// RuntimeClass, and squat/generic-device-plugin pinned to a multi-arch digest.
+// It exposes a harmless marker device for scheduling tests; it does not make
+// the Apple GPU available to a workload.
+
+//go:embed assets/gpu/namespace.yaml
+var gpuNamespaceManifest string
+
+//go:embed assets/gpu/runtimeclass.yaml
+var gpuRuntimeClassManifest string
+
+//go:embed assets/gpu/device-plugin.yaml
+var gpuDevicePluginManifest string
+
+func gpuMockManifests() []string {
+	return []string{
+		gpuNamespaceManifest,
+		gpuRuntimeClassManifest,
+		gpuDevicePluginManifest,
+	}
+}

--- a/pkg/cluster/gpu_test.go
+++ b/pkg/cluster/gpu_test.go
@@ -1,0 +1,66 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestGPUMockManifests(t *testing.T) {
+	manifests := []struct {
+		name     string
+		manifest string
+		contains []string
+	}{
+		{"namespace", gpuNamespaceManifest, []string{"kind: Namespace", "name: " + gpuNamespace}},
+		{"runtimeclass", gpuRuntimeClassManifest, []string{"kind: RuntimeClass", "name: " + gpuRuntimeClass, "handler: runc"}},
+		{"device-plugin", gpuDevicePluginManifest, []string{
+			"kind: DaemonSet", "name: " + gpuDevicePlugin, "--domain=" + gpuResourceDomain,
+			"path: /dev/null", "mountPath: " + gpuMockDevicePath,
+		}},
+	}
+	if got := len(gpuMockManifests()); got != len(manifests) {
+		t.Fatalf("gpuMockManifests() returned %d manifests, want %d", got, len(manifests))
+	}
+	for _, item := range manifests {
+		if got := decodeAll(t, item.name, item.manifest); got != 1 {
+			t.Errorf("%s parsed as %d documents, want 1", item.name, got)
+		}
+		for _, want := range item.contains {
+			if !strings.Contains(item.manifest, want) {
+				t.Errorf("%s: missing %q", item.name, want)
+			}
+		}
+	}
+
+	var devicePlugin map[string]any
+	if err := yaml.Unmarshal([]byte(gpuDevicePluginManifest), &devicePlugin); err != nil {
+		t.Fatal(err)
+	}
+	images := collectImages(devicePlugin)
+	wantImage := "docker.io/squat/generic-device-plugin:0.2.0@sha256:66c8d5c270eb2b721f1064c549b9b7898152a6d2f0163380a5d37dc7636c20ff"
+	if len(images) != 1 || images[0] != wantImage {
+		t.Fatalf("device-plugin images = %v, want [%s]", images, wantImage)
+	}
+	if strings.Contains(gpuDevicePluginManifest, "privileged:") {
+		t.Error("mock device plugin should not need a privileged container")
+	}
+}
+
+func TestPositiveResourceQuantity(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{{"1", true}, {" 2 ", true}, {"0", false}, {"", false}, {"1m", false}, {"nope", false}} {
+		if got := positiveResourceQuantity(tc.value); got != tc.want {
+			t.Errorf("positiveResourceQuantity(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestEscapedJSONPathKey(t *testing.T) {
+	if got, want := escapedJSONPathKey("kiac.dev/gpu.api"), `kiac\.dev/gpu\.api`; got != want {
+		t.Errorf("escapedJSONPathKey = %q, want %q", got, want)
+	}
+}

--- a/pkg/cluster/k3s.go
+++ b/pkg/cluster/k3s.go
@@ -385,6 +385,11 @@ func (m *Manager) CreateK3s(cfg Config) error {
 			ui.Infof("gateway stack not installed: %v", err)
 		}
 	}
+	if cfg.GPUMock {
+		if err := m.installGPUK3s(cp, cfg); err != nil {
+			ui.Infof("mock GPU scheduling not installed: %v", err)
+		}
+	}
 
 	var kubeconfigPath string
 	if err := ui.Step("Writing kubeconfig", func() error {

--- a/pkg/cluster/support.go
+++ b/pkg/cluster/support.go
@@ -157,6 +157,22 @@ func (c *supportCollector) collectKubernetes(m *Manager, cp, distro string, repo
 			args []string
 		}{"gateway.txt", []string{"get", "gatewayclasses,gateways,httproutes", "-A", "-o", "wide"}})
 	}
+	if verificationStatus(report, "gpu.device-plugin") != VerificationSkip {
+		commands = append(commands,
+			struct {
+				file string
+				args []string
+			}{"gpu-runtimeclass.txt", []string{"get", "runtimeclass", gpuRuntimeClass, "-o", "wide"}},
+			struct {
+				file string
+				args []string
+			}{"gpu-device-plugin.txt", []string{"get", "daemonset", gpuDevicePlugin, "-n", gpuNamespace, "-o", "wide"}},
+			struct {
+				file string
+				args []string
+			}{"gpu-nodes.txt", []string{"get", "nodes", "-l", gpuLabelPresent + "=true", "-o", "wide"}},
+		)
+	}
 	for _, command := range commands {
 		out, err := m.diagnosticKubectl(cp, distro, timeout, command.args...)
 		full := "container exec " + cp + " kubectl " + strings.Join(command.args, " ")

--- a/pkg/cluster/verify.go
+++ b/pkg/cluster/verify.go
@@ -231,6 +231,9 @@ func (r *VerificationReport) skipKubernetesDataChecks(reason string) {
 		{"metrics.api", "metrics API"},
 		{"gateway.api", "Gateway API"},
 		{"observability.stack", "observability"},
+		{"gpu.runtime-class", "GPU RuntimeClass"},
+		{"gpu.device-plugin", "mock GPU device plugin"},
+		{"gpu.nodes", "GPU node resources"},
 	} {
 		r.add(VerificationSkip, check.id, check.name, reason, "")
 	}
@@ -403,6 +406,127 @@ func (m *Manager) verifyOptionalKubernetesAddons(report *VerificationReport, cp 
 			report.add(VerificationPass, "observability.stack", "observability", "Grafana: http://"+strings.TrimSpace(address)+":3000", "")
 		}
 	}
+
+	m.verifyGPUAddon(report, cp, timeout)
+}
+
+func (m *Manager) verifyGPUAddon(report *VerificationReport, cp string, timeout time.Duration) {
+	out, err := m.diagnosticKubectl(cp, report.Distro, timeout, "get", "daemonset", gpuDevicePlugin,
+		"-n", gpuNamespace, "--ignore-not-found", "-o", "json")
+	if err != nil {
+		report.add(VerificationWarn, "gpu.device-plugin", "mock GPU device plugin", compactError(err),
+			"kubectl get daemonset -n "+gpuNamespace)
+		report.add(VerificationSkip, "gpu.runtime-class", "GPU RuntimeClass", "device-plugin state is unavailable", "")
+		report.add(VerificationSkip, "gpu.nodes", "GPU node resources", "device-plugin state is unavailable", "")
+		return
+	}
+	if strings.TrimSpace(out) == "" {
+		report.add(VerificationSkip, "gpu.device-plugin", "mock GPU device plugin", "not installed (--gpu-mock was not used)", "")
+		report.add(VerificationSkip, "gpu.runtime-class", "GPU RuntimeClass", "mock GPU scheduling is not installed", "")
+		report.add(VerificationSkip, "gpu.nodes", "GPU node resources", "mock GPU scheduling is not installed", "")
+		return
+	}
+
+	runtimeClassOut, runtimeClassErr := m.diagnosticKubectl(cp, report.Distro, timeout,
+		"get", "runtimeclass", gpuRuntimeClass, "--ignore-not-found", "-o", "json")
+	if runtimeClassErr != nil {
+		report.add(VerificationFail, "gpu.runtime-class", "GPU RuntimeClass", compactError(runtimeClassErr),
+			"kubectl get runtimeclass "+gpuRuntimeClass+" -o yaml")
+	} else if strings.TrimSpace(runtimeClassOut) == "" {
+		report.add(VerificationFail, "gpu.runtime-class", "GPU RuntimeClass", gpuRuntimeClass+" is missing",
+			"recreate the cluster with --gpu-mock")
+	} else {
+		var runtimeClass kubeRuntimeClass
+		if err := json.Unmarshal([]byte(runtimeClassOut), &runtimeClass); err != nil {
+			report.add(VerificationFail, "gpu.runtime-class", "GPU RuntimeClass", "cannot parse kubectl output: "+err.Error(), "")
+		} else if runtimeClass.Handler != "runc" {
+			report.add(VerificationFail, "gpu.runtime-class", "GPU RuntimeClass",
+				fmt.Sprintf("%s handler is %q, want runc", gpuRuntimeClass, runtimeClass.Handler),
+				"kubectl get runtimeclass "+gpuRuntimeClass+" -o yaml")
+		} else {
+			report.add(VerificationPass, "gpu.runtime-class", "GPU RuntimeClass", gpuRuntimeClass+" uses handler runc", "")
+		}
+	}
+
+	var daemonset kubeDaemonSet
+	if err := json.Unmarshal([]byte(out), &daemonset); err != nil {
+		report.add(VerificationFail, "gpu.device-plugin", "mock GPU device plugin", "cannot parse kubectl output: "+err.Error(), "")
+	} else if daemonset.Status.DesiredNumberScheduled == 0 ||
+		daemonset.Status.NumberReady != daemonset.Status.DesiredNumberScheduled ||
+		daemonset.Status.NumberAvailable != daemonset.Status.DesiredNumberScheduled {
+		report.add(VerificationFail, "gpu.device-plugin", "mock GPU device plugin",
+			fmt.Sprintf("%d/%d pod(s) Ready, %d available", daemonset.Status.NumberReady,
+				daemonset.Status.DesiredNumberScheduled, daemonset.Status.NumberAvailable),
+			"kubectl get pods -n "+gpuNamespace+" -o wide")
+	} else {
+		report.add(VerificationPass, "gpu.device-plugin", "mock GPU device plugin",
+			fmt.Sprintf("%d/%d pod(s) Ready and available", daemonset.Status.NumberReady, daemonset.Status.DesiredNumberScheduled), "")
+	}
+
+	out, err = m.diagnosticKubectl(cp, report.Distro, timeout, "get", "nodes", "-o", "json")
+	if err != nil {
+		report.add(VerificationFail, "gpu.nodes", "GPU node resources", compactError(err),
+			"kubectl get nodes -o json")
+		return
+	}
+	var nodes kubeNodeList
+	if err := json.Unmarshal([]byte(out), &nodes); err != nil {
+		report.add(VerificationFail, "gpu.nodes", "GPU node resources", "cannot parse kubectl output: "+err.Error(), "")
+		return
+	}
+	if len(nodes.Items) == 0 {
+		report.add(VerificationFail, "gpu.nodes", "GPU node resources", "device plugin is installed, but no Kubernetes nodes were found",
+			"kubectl get nodes -o wide")
+		return
+	}
+
+	bad := make([]string, 0)
+	type nodeResult struct {
+		name   string
+		status VerificationStatus
+		detail string
+	}
+	results := make([]nodeResult, 0, len(nodes.Items))
+	for _, node := range nodes.Items {
+		labels := node.Metadata.Labels
+		capacity := node.Status.Capacity[GPUResourceName]
+		var problems []string
+		if labels[gpuLabelPresent] != "true" {
+			problems = append(problems, gpuLabelPresent+" is not true")
+		}
+		for _, key := range []string{gpuLabelProduct, gpuLabelMemory, gpuLabelCount, gpuLabelAPI} {
+			if strings.TrimSpace(labels[key]) == "" {
+				problems = append(problems, key+" is missing")
+			}
+		}
+		if !positiveResourceQuantity(capacity) {
+			problems = append(problems, GPUResourceName+" capacity is "+orUnknown(capacity))
+		}
+		if count := labels[gpuLabelCount]; count != "" && capacity != "" && count != capacity {
+			problems = append(problems, gpuLabelCount+"="+count+" differs from capacity "+capacity)
+		}
+		if len(problems) > 0 {
+			bad = append(bad, node.Metadata.Name)
+			results = append(results, nodeResult{node.Metadata.Name, VerificationFail, strings.Join(problems, "; ")})
+		} else {
+			results = append(results, nodeResult{node.Metadata.Name, VerificationPass,
+				fmt.Sprintf("%s=%s, product=%s, api=%s", GPUResourceName, capacity, labels[gpuLabelProduct], labels[gpuLabelAPI])})
+		}
+	}
+	if len(bad) > 0 {
+		report.add(VerificationFail, "gpu.nodes", "GPU node resources", "invalid GPU contract on: "+limitedList(bad, 6),
+			"kubectl get nodes -o json")
+	} else {
+		report.add(VerificationPass, "gpu.nodes", "GPU node resources",
+			fmt.Sprintf("%d node(s) advertise %s", len(nodes.Items), GPUResourceName), "")
+	}
+	for _, result := range results {
+		hint := ""
+		if result.status == VerificationFail {
+			hint = "kubectl describe node " + result.name
+		}
+		report.add(result.status, "gpu.node."+result.name, "GPU node: "+result.name, result.detail, hint)
+	}
 }
 
 func (m *Manager) verifyNodeAddons(report *VerificationReport, infos []runtime.Info, cp string, timeout time.Duration) {
@@ -571,6 +695,7 @@ type kubeMetadata struct {
 	Namespace         string            `json:"namespace"`
 	DeletionTimestamp string            `json:"deletionTimestamp"`
 	Annotations       map[string]string `json:"annotations"`
+	Labels            map[string]string `json:"labels"`
 }
 
 type kubeCondition struct {
@@ -584,7 +709,8 @@ type kubeNodeList struct {
 	Items []struct {
 		Metadata kubeMetadata `json:"metadata"`
 		Status   struct {
-			Conditions []kubeCondition `json:"conditions"`
+			Conditions []kubeCondition   `json:"conditions"`
+			Capacity   map[string]string `json:"capacity"`
 		} `json:"status"`
 	} `json:"items"`
 }
@@ -621,6 +747,18 @@ type kubeAPIService struct {
 	Status struct {
 		Conditions []kubeCondition `json:"conditions"`
 	} `json:"status"`
+}
+
+type kubeDaemonSet struct {
+	Status struct {
+		DesiredNumberScheduled int `json:"desiredNumberScheduled"`
+		NumberReady            int `json:"numberReady"`
+		NumberAvailable        int `json:"numberAvailable"`
+	} `json:"status"`
+}
+
+type kubeRuntimeClass struct {
+	Handler string `json:"handler"`
 }
 
 type kubeGateway struct {

--- a/pkg/cluster/verify_test.go
+++ b/pkg/cluster/verify_test.go
@@ -29,6 +29,9 @@ func TestVerifyHealthyClusterData(t *testing.T) {
 		"network.load-balancer": VerificationSkip,
 		"gateway.api":           VerificationSkip,
 		"observability.stack":   VerificationSkip,
+		"gpu.runtime-class":     VerificationSkip,
+		"gpu.device-plugin":     VerificationSkip,
+		"gpu.nodes":             VerificationSkip,
 	}
 	for id, status := range want {
 		if got := verificationStatus(report, id); got != status {
@@ -68,6 +71,59 @@ func TestVerifyReportsMissingBuiltInGateway(t *testing.T) {
 	}
 }
 
+func TestVerifyReportsHealthyMockGPU(t *testing.T) {
+	t.Setenv("KIAC_TEST_GPU", "true")
+	report, err := fakeVerificationManager(t).Verify("dev", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"gpu.runtime-class", "gpu.device-plugin", "gpu.nodes", "gpu.node.kiac-dev-control-plane"} {
+		if got := verificationStatus(report, id); got != VerificationPass {
+			t.Errorf("check %s = %s, want pass", id, got)
+		}
+	}
+}
+
+func TestVerifyReportsMissingMockGPUCapacity(t *testing.T) {
+	t.Setenv("KIAC_TEST_GPU", "true")
+	t.Setenv("KIAC_TEST_GPU_CAPACITY", "0")
+	report, err := fakeVerificationManager(t).Verify("dev", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"gpu.nodes", "gpu.node.kiac-dev-control-plane"} {
+		if got := verificationStatus(report, id); got != VerificationFail {
+			t.Errorf("check %s = %s, want fail", id, got)
+		}
+	}
+}
+
+func TestVerifyReportsWrongGPURuntimeClass(t *testing.T) {
+	t.Setenv("KIAC_TEST_GPU", "true")
+	t.Setenv("KIAC_TEST_GPU_HANDLER", "nvidia")
+	report, err := fakeVerificationManager(t).Verify("dev", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := verificationStatus(report, "gpu.runtime-class"); got != VerificationFail {
+		t.Errorf("gpu.runtime-class = %s, want fail", got)
+	}
+}
+
+func TestVerifyReportsNodeThatLostGPULabel(t *testing.T) {
+	t.Setenv("KIAC_TEST_GPU", "true")
+	t.Setenv("KIAC_TEST_GPU_LABELS", "missing")
+	report, err := fakeVerificationManager(t).Verify("dev", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"gpu.nodes", "gpu.node.kiac-dev-control-plane"} {
+		if got := verificationStatus(report, id); got != VerificationFail {
+			t.Errorf("check %s = %s, want fail", id, got)
+		}
+	}
+}
+
 func TestDistroFromNodes(t *testing.T) {
 	if got := distroFromNodes([]runtime.Info{{Image: "docker.io/rancher/k3s:v1.36.2-k3s1"}}); got != "k3s" {
 		t.Errorf("k3s image detected as %q", got)
@@ -104,7 +160,12 @@ case "$*" in
     printf 'ok\n'
     ;;
   *"get nodes -o json"*)
-    printf '%s\n' '{"items":[{"metadata":{"name":"kiac-dev-control-plane"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
+    if [ "${KIAC_TEST_GPU:-}" = true ] && [ "${KIAC_TEST_GPU_LABELS:-}" != missing ]; then
+      capacity="${KIAC_TEST_GPU_CAPACITY:-1}"
+      printf '{"items":[{"metadata":{"name":"kiac-dev-control-plane","labels":{"kiac.dev/gpu.present":"true","kiac.dev/gpu.product":"Mock","kiac.dev/gpu.memory":"0","kiac.dev/gpu.count":"1","kiac.dev/gpu.api":"mock"}},"status":{"conditions":[{"type":"Ready","status":"True"}],"capacity":{"kiac.dev/gpu":"%s"}}}]}\n' "$capacity"
+    else
+      printf '%s\n' '{"items":[{"metadata":{"name":"kiac-dev-control-plane"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
+    fi
     ;;
   *"get pods -A -o json"*)
     phase="${KIAC_TEST_POD_PHASE:-Running}"
@@ -115,6 +176,16 @@ case "$*" in
     ;;
   *"get storageclass -o json"*)
     printf '%s\n' '{"items":[{"metadata":{"name":"standard","annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}]}'
+    ;;
+  *"get daemonset kiac-gpu-device-plugin -n kiac-gpu-system"*)
+    if [ "${KIAC_TEST_GPU:-}" = true ]; then
+      printf '%s\n' '{"status":{"desiredNumberScheduled":1,"numberReady":1,"numberAvailable":1}}'
+    fi
+    ;;
+  *"get runtimeclass kiac-gpu --ignore-not-found -o json"*)
+    if [ "${KIAC_TEST_GPU:-}" = true ]; then
+      printf '{"handler":"%s"}\n' "${KIAC_TEST_GPU_HANDLER:-runc}"
+    fi
     ;;
   *"get crd gateways.gateway.networking.k8s.io"*)
     if [ "${KIAC_TEST_GATEWAY_CRD:-}" = true ]; then

--- a/pkg/webui/index.html
+++ b/pkg/webui/index.html
@@ -150,6 +150,7 @@
         <label><input type="checkbox" id="storage" checked> local-path storage</label>
         <label><input type="checkbox" id="observability"> Observability <small>Prometheus + Grafana</small></label>
         <label><input type="checkbox" id="gateway"> Gateway API <small>Traefik</small></label>
+        <label><input type="checkbox" id="gpu-mock"> Mock GPU scheduling <small>no acceleration</small></label>
       </div>
       <button class="primary" id="go">Create cluster</button>
     </form>
@@ -319,6 +320,7 @@ $('f').addEventListener('submit', async e => {
     cpus: $('cpus').value.trim(), memory: $('memory').value.trim(),
     noLB: !$('lb').checked, noMetrics: !$('metrics').checked, noStorage: !$('storage').checked,
     observability: $('observability').checked, gateway: $('gateway').checked,
+    gpuMock: $('gpu-mock').checked,
   };
   const r = await j('/api/clusters', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(body) });
   if (r.error) { alert(r.error); return; }

--- a/pkg/webui/webui.go
+++ b/pkg/webui/webui.go
@@ -143,6 +143,7 @@ func (s *server) meta(w http.ResponseWriter, r *http.Request) {
 		"defaultK3sVersion": cluster.DefaultK3sVersion,
 		"cnis":              []string{"kindnet", "cilium", "none"},
 		"distros":           []string{"kubeadm", "k3s"},
+		"gpuResourceName":   cluster.GPUResourceName,
 	})
 }
 
@@ -390,6 +391,7 @@ type createReq struct {
 	NoStorage     bool   `json:"noStorage"`
 	Observability bool   `json:"observability"`
 	Gateway       bool   `json:"gateway"`
+	GPUMock       bool   `json:"gpuMock"`
 }
 
 func sanitizeName(s string) bool { return cluster.ValidName(s) }
@@ -410,6 +412,16 @@ func (s *server) createCluster(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 400, map[string]string{"error": "distro must be kubeadm or k3s"})
 		return
 	}
+	args := createClusterArgs(req)
+	id, err := s.startJob(req.Name, args)
+	if err != nil {
+		writeJSON(w, 409, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, 202, map[string]string{"job": id})
+}
+
+func createClusterArgs(req createReq) []string {
 	args := []string{"create", "cluster", "--name", req.Name,
 		"--workers", strconv.Itoa(req.Workers)}
 	if req.K8sVersion != "" {
@@ -447,12 +459,10 @@ func (s *server) createCluster(w http.ResponseWriter, r *http.Request) {
 	if req.Gateway {
 		args = append(args, "--gateway")
 	}
-	id, err := s.startJob(req.Name, args)
-	if err != nil {
-		writeJSON(w, 409, map[string]string{"error": err.Error()})
-		return
+	if req.GPUMock {
+		args = append(args, "--gpu-mock")
 	}
-	writeJSON(w, 202, map[string]string{"job": id})
+	return args
 }
 
 func (s *server) deleteCluster(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webui/webui_test.go
+++ b/pkg/webui/webui_test.go
@@ -96,6 +96,7 @@ func TestMetaHasDistroSpecificVersionDefaults(t *testing.T) {
 		DefaultVersion    string   `json:"defaultVersion"`
 		K3sVersions       []string `json:"k3sVersions"`
 		DefaultK3sVersion string   `json:"defaultK3sVersion"`
+		GPUResourceName   string   `json:"gpuResourceName"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatal(err)
@@ -108,6 +109,25 @@ func TestMetaHasDistroSpecificVersionDefaults(t *testing.T) {
 	}
 	if got.DefaultVersion == got.DefaultK3sVersion {
 		t.Fatalf("expected distro defaults to differ while k3s 1.37 is unavailable; both are %q", got.DefaultVersion)
+	}
+	if got.GPUResourceName != cluster.GPUResourceName {
+		t.Fatalf("gpuResourceName = %q, want %q", got.GPUResourceName, cluster.GPUResourceName)
+	}
+}
+
+func TestCreateClusterArgsGPUAndDistro(t *testing.T) {
+	args := createClusterArgs(createReq{
+		Name: "gpu", Workers: 2, K8sVersion: "1.36", Distro: "k3s", CNI: "cilium",
+		CPUs: "6", Memory: "8G", GPUMock: true,
+	})
+	joined := " " + strings.Join(args, " ") + " "
+	for _, want := range []string{" --distro k3s ", " --gpu-mock ", " --cpus 6 ", " --memory 8G "} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args %q do not contain %q", joined, want)
+		}
+	}
+	if strings.Contains(joined, " --cni ") {
+		t.Errorf("k3s args unexpectedly contain --cni: %q", joined)
 	}
 }
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -203,6 +203,24 @@ test_observability() {
     "http://$(url_host "${grafana_ip}"):3000/api/health" >/dev/null
 }
 
+test_gpu_mock() {
+  [[ "$(k get runtimeclass kiac-gpu -o jsonpath='{.handler}')" == runc ]]
+  k -n kiac-gpu-system rollout status daemonset/kiac-gpu-device-plugin --timeout=180s
+  local node capacity api
+  for node in ${CURRENT_NODES}; do
+    capacity=$(k get node "${node}" -o 'jsonpath={.status.capacity.kiac\.dev/gpu}')
+    api=$(k get node "${node}" -o 'jsonpath={.metadata.labels.kiac\.dev/gpu\.api}')
+    [[ "${capacity}" == 1 && "${api}" == mock ]] || {
+      printf '%s mock GPU contract capacity=%q api=%q, want 1/mock\n' "${node}" "${capacity}" "${api}" >&2
+      return 1
+    }
+  done
+  k apply -f "${ROOT}/examples/gpu-mock.yaml"
+  k wait --for=jsonpath='{.status.phase}'=Succeeded pod/kiac-gpu-mock-check --timeout=120s
+  k logs pod/kiac-gpu-mock-check | grep -F 'no hardware acceleration is enabled' >/dev/null
+  k delete -f "${ROOT}/examples/gpu-mock.yaml" --wait=true
+}
+
 assert_k3s_node_addresses() {
   local node vm_ip internal_ips kindnet_ip node_exporter_ip saved_url live_url
   local cp="kiac-${CURRENT_CLUSTER}-control-plane"
@@ -273,7 +291,7 @@ run_cluster() {
   local create=(create cluster --name "${name}" --distro "${distro}" --workers "${workers}" --ip-family "${family}" --wait 8m
     --mount "type=bind,source=${mount_dir},target=/kiac-e2e-host")
   if [[ "${features}" == true ]]; then
-    create+=(--gateway --observability)
+    create+=(--gateway --observability --gpu-mock)
   fi
 
   printf '\n=== %s: %s %s, %s workers ===\n' "${label}" "${distro}" "${family}" "${workers}"
@@ -353,6 +371,7 @@ run_cluster() {
   if [[ "${features}" == true ]]; then
     test_gateway
     test_observability
+    test_gpu_mock
   fi
 
   if [[ "${restart}" == true ]]; then
@@ -396,6 +415,7 @@ run_cluster() {
       if [[ "${features}" == true ]]; then
         test_gateway
         test_observability
+        test_gpu_mock
       fi
       "${KIAC_BIN}" verify cluster --name "${name}"
     else
@@ -410,6 +430,9 @@ run_cluster() {
       # must have persisted and is checked immediately above.
       install_traffic_binary "${sender}"
       retry 5 2 test_upload "${sender}" "${ingress}" v4
+      if [[ "${features}" == true ]]; then
+        test_gpu_mock
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary

- add opt-in `--gpu-mock` scheduling support to kubeadm and k3s clusters
- advertise one synthetic `kiac.dev/gpu` per node through a small, digest-pinned device plugin
- add the `kiac-gpu` RuntimeClass, node contract labels, config-file and dashboard support
- extend `kiac verify` and support bundles with GPU-specific diagnostics
- add a runnable workload, lab, website documentation, E2E coverage, and the phased real-acceleration build plan

## Honest alpha boundary

This mode validates GPU-aware scheduling and chart integration only. It maps `/dev/null` as a marker device and does not expose or accelerate with the Apple GPU, Metal, CUDA, or Vulkan.

The RuntimeClass is deliberately named `kiac-gpu`. A real k3s validation caught that k3s already owns an immutable `nvidia` RuntimeClass, so kiac neither replaces nor impersonates that vendor runtime.

## Validation

- `GOTOOLCHAIN=go1.25.12 make ci`
- fresh kubeadm v1.36.1 cluster: example Pod requested `kiac.dev/gpu`, used `kiac-gpu`, saw `/dev/kiac-mock-gpu`, and succeeded
- fresh k3s v1.36.2 cluster: same workload and all GPU verification checks passed
- four-node k3s cluster (control plane + 3 workers): `4/4` plugin Pods ready and all four nodes independently advertised `kiac.dev/gpu=1`
- temporary validation clusters deleted after testing
