### PR TITLE
ci: materialize release tags on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,11 @@ jobs:
               echo "release ${RELEASE_TAG} already exists and is not a draft" >&2
               exit 1
             fi
+            draft_target="$(gh release view "${RELEASE_TAG}" --json targetCommitish --jq .targetCommitish)"
+            if [[ "${draft_target}" != "${GITHUB_SHA}" ]]; then
+              echo "release draft ${RELEASE_TAG} targets ${draft_target}, expected ${GITHUB_SHA}" >&2
+              exit 1
+            fi
           else
             gh release create "${RELEASE_TAG}" \
               --draft \
@@ -95,7 +100,8 @@ jobs:
               --title "${RELEASE_TAG}"
           fi
 
-          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          # GitHub materializes an immutable release tag only when its draft is published.
+          git tag --annotate "${RELEASE_TAG}" "${GITHUB_SHA}" --message "kiac ${RELEASE_TAG}"
           tag_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
           if [[ "${tag_sha}" != "${GITHUB_SHA}" ]]; then
             echo "release tag ${RELEASE_TAG} points to ${tag_sha}, expected ${GITHUB_SHA}" >&2
@@ -164,10 +170,26 @@ jobs:
             git -C "${tap_dir}" push origin HEAD:main
           fi
 
-      - name: Publish immutable release
+      - name: Publish and verify immutable release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit "${RELEASE_TAG}" --draft=false --verify-tag
+        shell: bash
+        run: |
+          gh release edit "${RELEASE_TAG}" --draft=false
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          tag_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          if [[ "${tag_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "published tag ${RELEASE_TAG} points to ${tag_sha}, expected ${GITHUB_SHA}" >&2
+            exit 1
+          fi
+          immutable="$(gh api \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            --jq .immutable)"
+          if [[ "${immutable}" != "true" ]]; then
+            echo "published release ${RELEASE_TAG} is not immutable" >&2
+            exit 1
+          fi
 
       - name: Remove deploy key
         if: always()

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,7 +27,7 @@ make ci
 gh workflow run Release --ref main -f tag=vX.Y.Z
 ```
 
-The workflow creates a draft release and its tag through GitHub's release API, uploads and verifies every artifact, and publishes only after all gates pass. This draft-first flow is required while immutable releases are enabled; direct creation of a release tag is intentionally blocked.
+The workflow reserves the tag in a draft release through GitHub's release API, uploads and verifies every artifact, and publishes only after all gates pass. GitHub materializes and locks the tag when the draft is published. This draft-first flow is required while immutable releases are enabled; direct creation of a release tag is intentionally blocked.
 
 After the workflow succeeds, verify both the artifact provenance and GitHub's immutable release attestation:
 


### PR DESCRIPTION
## Summary

- build from a local annotated tag while the immutable release remains a draft
- verify an existing draft targets the exact workflow commit
- let GitHub materialize the remote tag when the draft is published
- verify the published tag SHA and immutable release flag

## Context

The first v0.7.0 workflow run proved that GitHub reserves a tag name in an immutable draft but does not create the Git ref until publication. It stopped before build/upload and left no assets or remote tag; that empty draft has been deleted.

## Validation

- actionlint v1.7.12
- GoReleaser v2.17.1 check
- git diff --check