### PR TITLE
ci: use lightweight local release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           fi
 
           # GitHub materializes an immutable release tag only when its draft is published.
-          git tag --annotate "${RELEASE_TAG}" "${GITHUB_SHA}" --message "kiac ${RELEASE_TAG}"
+          git tag "${RELEASE_TAG}" "${GITHUB_SHA}"
           tag_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
           if [[ "${tag_sha}" != "${GITHUB_SHA}" ]]; then
             echo "release tag ${RELEASE_TAG} points to ${tag_sha}, expected ${GITHUB_SHA}" >&2


### PR DESCRIPTION
## Summary

Use a lightweight tag for GoReleaser version discovery inside the clean Actions checkout. GitHub still creates and locks the authoritative remote tag when the draft release is published.

## Why

The second unpublished v0.7.0 run confirmed that an annotated local tag requires a committer identity on a clean runner. No annotation is needed for a build-local tag.

## Validation

- actionlint v1.7.12
- git diff --check