### PR TITLE
fix: validate cluster inputs and bound readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ One honest caveat is tracked upstream in apple/container's vmnet layer: after `k
 
 Full guides and command reference live on the [docs site](https://saiyam1814.github.io/kiac/).
 
+`create cluster`, `delete cluster`, `get clusters`, and `get nodes` reject extra positional arguments. Select a cluster with `--name` where supported, for example `kiac delete cluster --name dev`, rather than `kiac delete cluster dev`. Creation requires a positive `--wait` duration. K3s also accepts full release versions such as `v1.36.4+k3s1` or `v1.36.4-k3s1`, preserving an explicit K3s build revision.
+
 ### Flags for `create cluster`
 
 | Flag | Default | Description |
@@ -317,7 +319,7 @@ Full guides and command reference live on the [docs site](https://saiyam1814.git
 | `--observability` | `false` | install Prometheus + Grafana + node-exporter; Grafana uses a LoadBalancer IP or ClusterIP with `--no-lb` |
 | `--gateway` | `false` | install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway |
 | `--config` | | cluster config YAML (see [`examples/cluster.yaml`](examples/cluster.yaml)); flags set explicitly on the command line override file values (`--kernel` is flag-only) |
-| `--wait` | `5m` | timeout for each readiness step, including CNI installation |
+| `--wait` | `5m` | positive timeout for each readiness step, including CNI installation; zero and negative values are rejected |
 
 ## How it works
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -19,6 +19,7 @@ var createCmd = &cobra.Command{
 var createClusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "Create a Kubernetes cluster of lightweight-VM nodes",
+	Args:  cobra.NoArgs,
 	Example: `  kiac create cluster
   kiac create cluster --name dev --workers 2
   kiac create cluster --memory 8G --cpus 4
@@ -41,6 +42,9 @@ var createClusterCmd = &cobra.Command{
 			if err := fc.Merge(&createCfg, &selectedDistro, &selectedK8sVersion, cmd.Flags().Changed); err != nil {
 				return err
 			}
+		}
+		if createCfg.WaitTimeout <= 0 {
+			return fmt.Errorf("--wait must be > 0")
 		}
 		if createCfg.Workers < 0 {
 			return fmt.Errorf("--workers must be >= 0")

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/saiyam1814/kiac/pkg/cluster"
+	"github.com/spf13/cobra"
 )
 
 func TestDefaultK8sVersionUsesDistroReleaseStream(t *testing.T) {
@@ -12,5 +17,79 @@ func TestDefaultK8sVersionUsesDistroReleaseStream(t *testing.T) {
 	}
 	if got := defaultK8sVersion("k3s"); got != cluster.DefaultK3sVersion {
 		t.Fatalf("k3s default = %q, want %q", got, cluster.DefaultK3sVersion)
+	}
+}
+
+func TestFlagOnlyClusterCommandsRejectArgs(t *testing.T) {
+	for _, command := range []*cobra.Command{createClusterCmd, deleteClusterCmd, getClustersCmd, getNodesCmd} {
+		t.Run(command.CommandPath(), func(t *testing.T) {
+			if err := command.ValidateArgs(nil); err != nil {
+				t.Fatalf("ValidateArgs(nil): %v", err)
+			}
+			for _, args := range [][]string{{"prod"}, {"prod", "extra"}} {
+				if err := command.ValidateArgs(args); err == nil {
+					t.Errorf("ValidateArgs(%q) accepted unexpected positional arguments", args)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateClusterWaitValidation(t *testing.T) {
+	cases := []struct {
+		name       string
+		configWait string
+		flagWait   string
+		wantWait   time.Duration
+		wantErr    string
+	}{
+		{name: "default wait", wantWait: 5 * time.Minute, wantErr: "kernel file"},
+		{name: "positive flag", flagWait: "1ns", wantWait: time.Nanosecond, wantErr: "kernel file"},
+		{name: "zero flag", flagWait: "0", wantErr: "--wait must be > 0"},
+		{name: "negative flag", flagWait: "-1s", wantWait: -time.Second, wantErr: "--wait must be > 0"},
+		{name: "positive config", configWait: "2m", wantWait: 2 * time.Minute, wantErr: "kernel file"},
+		{name: "zero config", configWait: "0s", wantWait: 5 * time.Minute, wantErr: `invalid wait "0s" in config file (must be > 0)`},
+		{name: "negative config", configWait: "-1s", wantWait: 5 * time.Minute, wantErr: `invalid wait "-1s" in config file (must be > 0)`},
+		{name: "zero flag overrides positive config", configWait: "2m", flagWait: "0s", wantErr: "--wait must be > 0"},
+		{name: "negative flag overrides positive config", configWait: "2m", flagWait: "-1s", wantWait: -time.Second, wantErr: "--wait must be > 0"},
+		{name: "positive flag overrides zero config", configWait: "0s", flagWait: "3m", wantWait: 3 * time.Minute, wantErr: "kernel file"},
+		{name: "positive flag overrides negative config", configWait: "-1s", flagWait: "3m", wantWait: 3 * time.Minute, wantErr: "kernel file"},
+		{name: "positive flag overrides malformed config", configWait: "banana", flagWait: "3m", wantWait: 3 * time.Minute, wantErr: "kernel file"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldCfg, oldConfigFile := createCfg, createConfigFile
+			oldKernel, oldIPFamily := createKernel, createIPFamily
+			t.Cleanup(func() {
+				createCfg, createConfigFile = oldCfg, oldConfigFile
+				createKernel, createIPFamily = oldKernel, oldIPFamily
+			})
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			createCfg = cluster.Config{Name: "invalid name"}
+			createConfigFile = ""
+			createKernel = filepath.Join(dir, "missing-kernel")
+			createIPFamily = "ipv4"
+			command := &cobra.Command{}
+			command.Flags().DurationVar(&createCfg.WaitTimeout, "wait", 5*time.Minute, "")
+			if tc.configWait != "" {
+				createConfigFile = filepath.Join(dir, "cluster.yaml")
+				if err := os.WriteFile(createConfigFile, []byte("wait: "+tc.configWait+"\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.flagWait != "" {
+				if err := command.ParseFlags([]string{"--wait=" + tc.flagWait}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := createClusterCmd.RunE(command, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("RunE error = %v, want substring %q", err, tc.wantErr)
+			}
+			if createCfg.WaitTimeout != tc.wantWait {
+				t.Errorf("WaitTimeout = %s, want %s", createCfg.WaitTimeout, tc.wantWait)
+			}
+		})
 	}
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,6 +18,7 @@ var deleteCmd = &cobra.Command{
 var deleteClusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Short: "Delete a cluster and its kubeconfig entries",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ui.Banner(Version)
 		if !cluster.ValidName(deleteName) {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -24,6 +24,7 @@ var getClustersCmd = &cobra.Command{
 	Use:     "clusters",
 	Aliases: []string{"cluster"},
 	Short:   "List kiac clusters",
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		statuses, err := cluster.NewManager().Statuses()
 		if err != nil {
@@ -66,6 +67,7 @@ var getClustersCmd = &cobra.Command{
 var getNodesCmd = &cobra.Command{
 	Use:   "nodes",
 	Short: "List node VMs of a cluster",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		infos, err := cluster.NewManager().Nodes(getNodesName)
 		if err != nil {

--- a/docs/docs/cli-reference.html
+++ b/docs/docs/cli-reference.html
@@ -57,6 +57,7 @@
   <div class="kicker">Core concepts</div>
   <h1>CLI reference</h1>
   <p class="lede">Every command and flag, straight from the source. <code>kiac &lt;command&gt; --help</code> shows the same information in your terminal.</p>
+  <p><code>create cluster</code>, <code>delete cluster</code>, <code>get clusters</code>, and <code>get nodes</code> reject extra positional arguments. Use <code>--name</code> on commands that select a cluster, for example <code>kiac delete cluster --name dev</code>; a positional name is not a substitute for that flag.</p>
 
   <h2 id="create-cluster">kiac create cluster</h2>
   <p>Create a Kubernetes cluster of lightweight-VM nodes.</p>
@@ -94,9 +95,9 @@ kiac create cluster --config cluster.yaml</code></pre>
     <tr><td><code>--no-edge-proxy</code></td><td><code>false</code></td><td>skip the node-local edge proxy that fixes large TCP uploads through NodePorts and LoadBalancers</td></tr>
     <tr><td><code>--observability</code></td><td><code>false</code></td><td>install Prometheus + Grafana + node-exporter; Grafana uses a LoadBalancer IP or ClusterIP with <code>--no-lb</code></td></tr>
     <tr><td><code>--gateway</code></td><td><code>false</code></td><td>install Gateway API CRDs + Traefik with a ready-to-use GatewayClass and Gateway</td></tr>
-    <tr><td><code>--wait</code></td><td><code>5m</code></td><td>timeout for each cluster readiness step, including CNI installation; passed to Cilium as <code>--wait-duration</code></td></tr>
+    <tr><td><code>--wait</code></td><td><code>5m</code></td><td>positive timeout for each cluster readiness step, including CNI installation; zero and negative values are rejected. Passed to Cilium as <code>--wait-duration</code></td></tr>
   </table>
-  <p>Version resolution: a minor like <code>1.34</code> uses kiac's digest-pinned node image (<code>kindest/node</code>, or <code>rancher/k3s</code> with <code>--distro k3s</code>); an exact patch matches the pin when it is the pinned patch, otherwise falls back to the matching upstream tag unpinned.</p>
+  <p>Version resolution: a minor like <code>1.34</code> uses kiac's digest-pinned node image (<code>kindest/node</code>, or <code>rancher/k3s</code> with <code>--distro k3s</code>); an exact patch matches the pin when it is the pinned patch, otherwise falls back to the matching upstream tag unpinned. K3s also accepts full releases such as <code>v1.36.4+k3s1</code> and <code>v1.36.4-k3s1</code>. Explicit K3s build revisions are preserved, and a digest pin is reused only when the complete release tag matches.</p>
   <p><code>--kernel</code> is CLI-only. <code>distro</code> and the GPU options are also available as <a href="config-file.html">config file</a> keys.</p>
 
   <h2 id="delete-cluster">kiac delete cluster</h2>

--- a/docs/docs/config-file.html
+++ b/docs/docs/config-file.html
@@ -112,7 +112,7 @@ addons:
     <tr><td><code>cpus</code></td><td>string</td><td><code>"4"</code></td><td><code>--cpus</code></td></tr>
     <tr><td><code>memory</code></td><td>string</td><td><code>2G</code></td><td><code>--memory</code> (worker VMs)</td></tr>
     <tr><td><code>cpMemory</code></td><td>string</td><td><code>4G</code></td><td><code>--cp-memory</code> (control-plane VM)</td></tr>
-    <tr><td><code>wait</code></td><td>duration string (<code>5m</code>, <code>90s</code>)</td><td><code>5m</code></td><td><code>--wait</code></td></tr>
+    <tr><td><code>wait</code></td><td>positive duration string (<code>5m</code>, <code>90s</code>); zero and negative values are rejected</td><td><code>5m</code></td><td><code>--wait</code></td></tr>
     <tr><td><code>addons.metrics</code></td><td>bool</td><td><code>true</code></td><td><code>--no-metrics</code> (inverted)</td></tr>
     <tr><td><code>addons.storage</code></td><td>bool</td><td><code>true</code></td><td><code>--no-storage</code> (inverted)</td></tr>
     <tr><td><code>addons.loadBalancer</code></td><td>bool</td><td><code>true</code></td><td><code>--no-lb</code> (inverted)</td></tr>

--- a/pkg/cluster/configfile.go
+++ b/pkg/cluster/configfile.go
@@ -134,6 +134,9 @@ func (fc *FileConfig) Merge(cfg *Config, distro, k8sVersion *string, changed fun
 		if err != nil {
 			return fmt.Errorf("invalid wait %q in config file (want a duration like 5m): %w", fc.Wait, err)
 		}
+		if d <= 0 {
+			return fmt.Errorf("invalid wait %q in config file (must be > 0)", fc.Wait)
+		}
 		cfg.WaitTimeout = d
 	}
 	if fc.Addons.Metrics != nil && !changed("no-metrics") {

--- a/pkg/cluster/configfile_test.go
+++ b/pkg/cluster/configfile_test.go
@@ -378,6 +378,47 @@ func TestMerge(t *testing.T) {
 	}
 }
 
+func TestMergeWaitValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		wait    string
+		changed bool
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "positive", wait: "1ns", want: time.Nanosecond},
+		{name: "zero", wait: "0", want: 5 * time.Minute, wantErr: `invalid wait "0" in config file (must be > 0)`},
+		{name: "zero duration", wait: "0s", want: 5 * time.Minute, wantErr: `invalid wait "0s" in config file (must be > 0)`},
+		{name: "negative", wait: "-1s", want: 5 * time.Minute, wantErr: `invalid wait "-1s" in config file (must be > 0)`},
+		{name: "CLI overrides zero", wait: "0s", changed: true, want: 2 * time.Minute},
+		{name: "CLI overrides negative", wait: "-1s", changed: true, want: 2 * time.Minute},
+		{name: "CLI overrides malformed", wait: "banana", changed: true, want: 2 * time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, version := cliDefaults()
+			distro := "kubeadm"
+			if tc.changed {
+				cfg.WaitTimeout = 2 * time.Minute
+			}
+			file := FileConfig{Wait: tc.wait}
+			err := file.Merge(&cfg, &distro, &version, func(flag string) bool {
+				return flag == "wait" && tc.changed
+			})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Merge error = %v, want substring %q", err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.WaitTimeout != tc.want {
+				t.Errorf("WaitTimeout = %s, want %s", cfg.WaitTimeout, tc.want)
+			}
+		})
+	}
+}
+
 func TestMergeDistroPrecedence(t *testing.T) {
 	file := FileConfig{Distro: "k3s"}
 	for _, tc := range []struct {

--- a/pkg/cluster/k3s_test.go
+++ b/pkg/cluster/k3s_test.go
@@ -43,6 +43,72 @@ func TestResolveK3sImage(t *testing.T) {
 	}
 }
 
+func TestResolveK3sImageFullRelease(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{in: "v1.36.4+k3s1", want: k3sImages["1.36"]},
+		{in: "v1.36.4-k3s1", want: k3sImages["1.36"]},
+		{in: "1.36.4+k3s1", want: k3sImages["1.36"]},
+		{in: "1.36.4-k3s1", want: k3sImages["1.36"]},
+		{in: " \tv1.36.4+k3s1\n", want: k3sImages["1.36"]},
+		{in: "v1.36.4+k3s2", want: "docker.io/rancher/k3s:v1.36.4-k3s2"},
+		{in: "v1.36.4-k3s2", want: "docker.io/rancher/k3s:v1.36.4-k3s2"},
+		{in: "v1.36.4+k3s10", want: "docker.io/rancher/k3s:v1.36.4-k3s10"},
+		{in: "v1.36.4-k3s10", want: "docker.io/rancher/k3s:v1.36.4-k3s10"},
+		{in: "v1.36.3+k3s1", want: "docker.io/rancher/k3s:v1.36.3-k3s1"},
+		{in: "v1.36.3-k3s2", want: "docker.io/rancher/k3s:v1.36.3-k3s2"},
+		{in: "v1.19.1+k3s2", want: "docker.io/rancher/k3s:v1.19.1-k3s2"},
+		{in: "v1.36.4", want: k3sImages["1.36"]},
+		{in: "v1.36.3", want: "docker.io/rancher/k3s:v1.36.3-k3s1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ResolveK3sImage(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("ResolveK3sImage(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveK3sImageRejectsMalformedVersions(t *testing.T) {
+	for _, version := range []string{
+		"",
+		"latest",
+		"v1.36+k3s1",
+		"v1.36-k3s1",
+		"v1.36.4+k3s",
+		"v1.36.4-k3s",
+		"v1.36.4+k3sx",
+		"v1.36.4-k3s-1",
+		"v1.36.4-k3s1-k3s1",
+		"v1.36.4+k3s1+k3s2",
+		"v1.36.4+k3s1-k3s1",
+		"v1.36.4-k3s1+extra",
+		"v1.36.4+other1",
+		"v1.36.4-rc1+k3s1",
+		"v1.36.x+k3s1",
+		"v1.x.4-k3s1",
+		"vX.36.4",
+		"1..4",
+		"1.36.",
+		"v1.36.4.1",
+		"v1.36.4-k3s1@sha256:abc",
+		"v1.36.4 -k3s1",
+	} {
+		t.Run(version, func(t *testing.T) {
+			if got, err := ResolveK3sImage(version); err == nil {
+				t.Errorf("ResolveK3sImage(%q) = %q, want an error", version, got)
+			}
+		})
+	}
+}
+
 // Every pinned k3s image must be fully pinned: registry-qualified,
 // digest-pinned, and a real k3s tag.
 func TestK3sImagePins(t *testing.T) {

--- a/pkg/cluster/versions.go
+++ b/pkg/cluster/versions.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -69,13 +70,15 @@ var k3sImages = map[string]string{
 	"1.36": "docker.io/rancher/k3s:v1.36.4-k3s1@sha256:edad48e12bf81c3a09ac1c05c0c0ffaaa22145980b989d6fae84543a76b83657",
 }
 
+var k3sVersionRe = regexp.MustCompile(`^\d+\.\d+(?:\.\d+(?:[+-]k3s\d+)?)?$`)
+
 // ResolveK3sImage maps a Kubernetes version to a pinned rancher/k3s
 // image, mirroring ResolveImage. Full patch versions outside the pin
 // table fall back to the matching -k3s1 tag, unpinned.
 func ResolveK3sImage(version string) (string, error) {
 	v := strings.TrimPrefix(strings.TrimSpace(version), "v")
 	parts := strings.Split(v, ".")
-	if len(parts) < 2 {
+	if !k3sVersionRe.MatchString(v) {
 		return "", fmt.Errorf("invalid Kubernetes version %q (want e.g. %s)", version, DefaultK3sVersion)
 	}
 	minor := parts[0] + "." + parts[1]
@@ -83,10 +86,14 @@ func ResolveK3sImage(version string) (string, error) {
 		return img, nil
 	}
 	if len(parts) == 3 {
-		if img, ok := k3sImages[minor]; ok && strings.Contains(img, ":v"+v+"-k3s") {
+		v = strings.Replace(v, "+k3s", "-k3s", 1)
+		if !strings.Contains(v, "-k3s") {
+			v += "-k3s1"
+		}
+		if img, ok := k3sImages[minor]; ok && strings.Contains(img, ":v"+v+"@") {
 			return img, nil
 		}
-		return "docker.io/rancher/k3s:v" + v + "-k3s1", nil
+		return "docker.io/rancher/k3s:v" + v, nil
 	}
 	return "", fmt.Errorf("no pinned k3s image for Kubernetes %q (k3s-supported minors: %s)", version, strings.Join(SupportedK3sVersions(), ", "))
 }

--- a/pkg/runtime/container.go
+++ b/pkg/runtime/container.go
@@ -257,18 +257,30 @@ func (c *Client) ExecStdin(name string, r io.Reader, command ...string) error {
 // WaitReady polls until containerd inside the node answers, i.e. the VM
 // finished booting systemd and the kubelet's runtime is up.
 func (c *Client) WaitReady(name string, timeout time.Duration) error {
+	return waitReady(name, timeout, c.ExecTimeout)
+}
+
+func waitReady(name string, timeout time.Duration, probe func(string, time.Duration, ...string) (string, error)) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
-	for time.Now().Before(deadline) {
-		out, err := c.Exec(name, "systemctl", "is-active", "containerd")
+	var lastOutput string
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		out, err := probe(name, min(10*time.Second, remaining), "systemctl", "is-active", "containerd")
 		if err == nil && strings.TrimSpace(out) == "active" {
 			return nil
 		}
-		lastErr = err
-		time.Sleep(2 * time.Second)
+		lastOutput, lastErr = out, err
+		time.Sleep(min(2*time.Second, time.Until(deadline)))
 	}
 	if lastErr != nil {
 		return fmt.Errorf("node %s did not become ready: %w", name, lastErr)
+	}
+	if out := strings.TrimSpace(lastOutput); out != "" {
+		return fmt.Errorf("node %s did not become ready in %s: %s", name, timeout, out)
 	}
 	return fmt.Errorf("node %s did not become ready in %s", name, timeout)
 }

--- a/pkg/runtime/container_test.go
+++ b/pkg/runtime/container_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -47,6 +48,204 @@ func TestExecTimeout(t *testing.T) {
 	}
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("ExecTimeout took %s", elapsed)
+	}
+}
+
+func TestWaitReadyExecTimeout(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "container")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexec sleep 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	err := (&Client{Bin: bin}).WaitReady("node", time.Second)
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Errorf("WaitReady took %s for timeout 1s", elapsed)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("WaitReady error = %v, want context deadline", err)
+	}
+	var commandErr *CommandError
+	if !errors.As(err, &commandErr) {
+		t.Fatalf("WaitReady error = %v, want command error", err)
+	}
+	wantArgs := []string{"exec", "node", "systemctl", "is-active", "containerd"}
+	if !slices.Equal(commandErr.Args, wantArgs) {
+		t.Errorf("WaitReady command args = %q, want %q", commandErr.Args, wantArgs)
+	}
+}
+
+func TestWaitReadyTimeout(t *testing.T) {
+	firstErr := errors.New("first probe failed")
+	commandErr := &CommandError{
+		Tool:   "container",
+		Args:   []string{"exec", "node", "systemctl", "is-active", "containerd"},
+		Output: "containerd failed\n",
+		Err:    errors.New("exit status 3"),
+	}
+	for _, tc := range []struct {
+		name   string
+		output string
+		err    error
+	}{
+		{name: "failed_probe", output: commandErr.Output, err: commandErr},
+		{name: "inactive_probe", output: "  inactive \n"},
+		{name: "empty_probe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				const timeout = 2500 * time.Millisecond
+				probes := 0
+				started := time.Now()
+				err := waitReady("node", timeout, func(string, time.Duration, ...string) (string, error) {
+					probes++
+					if probes == 1 {
+						return "first probe failed\n", firstErr
+					}
+					return tc.output, tc.err
+				})
+				if elapsed := time.Since(started); elapsed != timeout {
+					t.Errorf("WaitReady took %s, want %s", elapsed, timeout)
+				}
+				if probes != 2 {
+					t.Errorf("WaitReady probes = %d, want 2", probes)
+				}
+				want := "node node did not become ready in " + timeout.String()
+				if tc.err != nil {
+					want = "node node did not become ready: " + tc.err.Error()
+					if !errors.Is(err, tc.err) {
+						t.Errorf("WaitReady error = %v, want wrapped last probe error %v", err, tc.err)
+					}
+				} else if out := strings.TrimSpace(tc.output); out != "" {
+					want += ": " + out
+				}
+				if err == nil || err.Error() != want {
+					t.Errorf("WaitReady error = %v, want %q", err, want)
+				}
+				if errors.Is(err, firstErr) {
+					t.Errorf("WaitReady retained an earlier probe error: %v", err)
+				}
+			})
+		})
+	}
+}
+
+func TestWaitReadyRemainingDeadline(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		timeout            time.Duration
+		firstProbeDuration time.Duration
+		wantTimeouts       []time.Duration
+	}{
+		{
+			name:               "short_wait",
+			timeout:            3500 * time.Millisecond,
+			firstProbeDuration: 250 * time.Millisecond,
+			wantTimeouts:       []time.Duration{3500 * time.Millisecond, 1250 * time.Millisecond},
+		},
+		{
+			name:               "probe_cap",
+			timeout:            15 * time.Second,
+			firstProbeDuration: 10 * time.Second,
+			wantTimeouts:       []time.Duration{10 * time.Second, 3 * time.Second},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				var timeouts []time.Duration
+				var lastErr *CommandError
+				started := time.Now()
+				err := waitReady("node", tc.timeout, func(name string, timeout time.Duration, command ...string) (string, error) {
+					timeouts = append(timeouts, timeout)
+					if len(timeouts) == 1 {
+						time.Sleep(tc.firstProbeDuration)
+						return "first probe failed\n", errors.New("first probe failed")
+					}
+					ctx, cancel := context.WithTimeout(context.Background(), timeout)
+					defer cancel()
+					<-ctx.Done()
+					lastErr = &CommandError{
+						Tool:   "container",
+						Args:   append([]string{"exec", name}, command...),
+						Output: "last probe still booting\n",
+						Err:    ctx.Err(),
+					}
+					return lastErr.Output, lastErr
+				})
+				if !slices.Equal(timeouts, tc.wantTimeouts) {
+					t.Errorf("WaitReady probe timeouts = %v, want %v", timeouts, tc.wantTimeouts)
+				}
+				if elapsed := time.Since(started); elapsed != tc.timeout {
+					t.Errorf("WaitReady took %s, want %s", elapsed, tc.timeout)
+				}
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Errorf("WaitReady error = %v, want context deadline", err)
+				}
+				var commandErr *CommandError
+				if !errors.As(err, &commandErr) || commandErr != lastErr {
+					t.Fatalf("WaitReady error = %v, want last probe command error %v", err, lastErr)
+				}
+				if !strings.Contains(err.Error(), strings.TrimSpace(lastErr.Output)) {
+					t.Errorf("WaitReady error = %v, want last probe output %q", err, lastErr.Output)
+				}
+			})
+		})
+	}
+}
+
+func TestWaitReadySuccess(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		wantProbes int
+	}{
+		{name: "immediate", wantProbes: 1},
+		{name: "after_retry", wantProbes: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				probes := 0
+				started := time.Now()
+				err := waitReady("node", 4*time.Second, func(name string, timeout time.Duration, command ...string) (string, error) {
+					probes++
+					if name != "node" || !slices.Equal(command, []string{"systemctl", "is-active", "containerd"}) {
+						t.Errorf("WaitReady probe = %q %q, want node systemctl is-active containerd", name, command)
+					}
+					if probes < tc.wantProbes {
+						return "activating\n", errors.New("exit status 3")
+					}
+					return "  active \n", nil
+				})
+				if err != nil {
+					t.Fatalf("WaitReady error = %v, want success", err)
+				}
+				if probes != tc.wantProbes {
+					t.Errorf("WaitReady probes = %d, want %d", probes, tc.wantProbes)
+				}
+				if elapsed, want := time.Since(started), time.Duration(tc.wantProbes-1)*2*time.Second; elapsed != want {
+					t.Errorf("WaitReady took %s, want %s", elapsed, want)
+				}
+			})
+		})
+	}
+}
+
+func TestWaitReadyNonPositiveTimeout(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		t.Run(timeout.String(), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				started := time.Now()
+				err := waitReady("node", timeout, func(string, time.Duration, ...string) (string, error) {
+					t.Fatal("WaitReady probed with a nonpositive timeout")
+					return "", nil
+				})
+				if elapsed := time.Since(started); elapsed != 0 {
+					t.Errorf("WaitReady took %s for timeout %s", elapsed, timeout)
+				}
+				want := "node node did not become ready in " + timeout.String()
+				if err == nil || err.Error() != want {
+					t.Errorf("WaitReady error = %v, want %q", err, want)
+				}
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reject extra positional arguments on flag-only create/delete/get commands, preventing an ignored cluster name from acting on the default cluster.
- Reject nonpositive creation waits before provisioning while preserving explicit flag-over-config precedence.
- Accept full K3s release versions, preserve explicit build revisions, and reuse image digests only for exact release matches.
- Bound containerd readiness probes and polling sleeps by the remaining wait budget, retaining useful failure diagnostics.
- Update the README and CLI/config documentation. No dependency or image-pin changes.

This branch is based directly on main and is independent of the other audit-fix PRs.

#### Test plan
- [x] `GOTOOLCHAIN=go1.26.6 make ci` in this isolated PR worktree: formatting, module tidiness, generated assets, GPU-agent tests/vet, root vet/race tests, and build.
- [x] Regression tests for argument rejection, wait validation/precedence, full K3s versions, revision preservation, and malformed versions.
- [x] Real fake-process timeout regression plus deterministic `testing/synctest` coverage for retry budgets and diagnostics.
- [x] Two independent local reviews of the final code and PR packaging; no remaining blockers.
- [ ] Full live ordinary-cluster boot/failure smoke matrix was not rerun for this PR; the readiness regressions use fake commands and virtual time.

Generated with [Devin](https://devin.ai)